### PR TITLE
Provide `--use-ssl` option

### DIFF
--- a/neptune-export/docs/create-pg-config.md
+++ b/neptune-export/docs/create-pg-config.md
@@ -12,7 +12,7 @@
                     [ --nlb-endpoint <networkLoadBalancerEndpoint> ]
                     [ {-p | --port} <port> ] [ {-s | --scope} <scope> ]
                     [ --sample ] [ --sample-size <sampleSize> ]
-                    [ {-t | --tag} <tag> ] [ --use-iam-auth ]
+                    [ {-t | --tag} <tag> ] [ --use-iam-auth ] [ --use-ssl ]
     
     OPTIONS
             --alb-endpoint <applicationLoadBalancerEndpoint>
@@ -128,6 +128,12 @@
                 Use IAM database authentication to authenticate to Neptune
                 (remember to set SERVICE_REGION environment variable, and, if using
                 a load balancer, set the --host-header option as well)
+    
+                This option may occur a maximum of 1 times
+    
+    
+            --use-ssl
+                Enables connectivity over SSL
     
                 This option may occur a maximum of 1 times
     

--- a/neptune-export/docs/export-pg-from-config.md
+++ b/neptune-export/docs/export-pg-from-config.md
@@ -14,7 +14,7 @@
                     [ --nlb-endpoint <networkLoadBalancerEndpoint> ]
                     [ {-p | --port} <port> ] [ {-r | --range} <range> ]
                     [ {-s | --scope} <scope> ] [ {-t | --tag} <tag> ]
-                    [ --use-iam-auth ]
+                    [ --use-iam-auth ] [ --use-ssl ]
     
     OPTIONS
             --alb-endpoint <applicationLoadBalancerEndpoint>
@@ -148,6 +148,12 @@
                 Use IAM database authentication to authenticate to Neptune
                 (remember to set SERVICE_REGION environment variable, and, if using
                 a load balancer, set the --host-header option as well)
+    
+                This option may occur a maximum of 1 times
+    
+    
+            --use-ssl
+                Enables connectivity over SSL
     
                 This option may occur a maximum of 1 times
     

--- a/neptune-export/docs/export-pg-from-queries.md
+++ b/neptune-export/docs/export-pg-from-queries.md
@@ -12,7 +12,7 @@
                     [ --lb-port <loadBalancerPort> ] [ --log-level <log level> ]
                     [ --nlb-endpoint <networkLoadBalancerEndpoint> ]
                     [ {-p | --port} <port> ] [ {-q | --queries} <queries>... ]
-                    [ {-t | --tag} <tag> ] [ --use-iam-auth ]
+                    [ {-t | --tag} <tag> ] [ --use-iam-auth ] [ --use-ssl ]
     
     OPTIONS
             --alb-endpoint <applicationLoadBalancerEndpoint>
@@ -134,6 +134,12 @@
                 Use IAM database authentication to authenticate to Neptune
                 (remember to set SERVICE_REGION environment variable, and, if using
                 a load balancer, set the --host-header option as well)
+    
+                This option may occur a maximum of 1 times
+    
+    
+            --use-ssl
+                Enables connectivity over SSL
     
                 This option may occur a maximum of 1 times
     

--- a/neptune-export/docs/export-pg.md
+++ b/neptune-export/docs/export-pg.md
@@ -14,7 +14,7 @@
                     [ {-p | --port} <port> ] [ {-r | --range} <range> ]
                     [ {-s | --scope} <scope> ] [ --sample ]
                     [ --sample-size <sampleSize> ] [ {-t | --tag} <tag> ]
-                    [ --use-iam-auth ]
+                    [ --use-iam-auth ] [ --use-ssl ]
     
     OPTIONS
             --alb-endpoint <applicationLoadBalancerEndpoint>
@@ -150,6 +150,12 @@
                 Use IAM database authentication to authenticate to Neptune
                 (remember to set SERVICE_REGION environment variable, and, if using
                 a load balancer, set the --host-header option as well)
+    
+                This option may occur a maximum of 1 times
+    
+    
+            --use-ssl
+                Enables connectivity over SSL
     
                 This option may occur a maximum of 1 times
     

--- a/neptune-export/docs/export-rdf.md
+++ b/neptune-export/docs/export-rdf.md
@@ -8,7 +8,7 @@
                     [ --lb-port <loadBalancerPort> ] [ --log-level <log level> ]
                     [ --nlb-endpoint <networkLoadBalancerEndpoint> ]
                     [ {-p | --port} <port> ] [ {-t | --tag} <tag> ]
-                    [ --use-iam-auth ]
+                    [ --use-iam-auth ] [ --use-ssl ]
     
     OPTIONS
             --alb-endpoint <applicationLoadBalancerEndpoint>
@@ -92,6 +92,12 @@
                 Use IAM database authentication to authenticate to Neptune
                 (remember to set SERVICE_REGION environment variable, and, if using
                 a load balancer, set the --host-header option as well)
+    
+                This option may occur a maximum of 1 times
+    
+    
+            --use-ssl
+                Enables connectivity over SSL
     
                 This option may occur a maximum of 1 times
     

--- a/neptune-export/readme.md
+++ b/neptune-export/readme.md
@@ -19,6 +19,12 @@ Exports Amazon Neptune property graph data to CSV or JSON, or RDF graph data to 
 
   - [Exporting an RDF Graph](#exporting-an-rdf-graph)
   
+### Encryption in transit
+
+You can connect to Neptune from _neptune-export_ using SSL by specifying the `--use-ssl` option.
+
+You cannot use the `--use-ssl` option with a network load balancer. As per the [Neptune security documentation](https://docs.aws.amazon.com/neptune/latest/userguide/security-ssl.html), if you are using a load balancer or a proxy server (such as HAProxy), you must use SSL termination and have your own SSL certificate on the proxy server. SSL passthrough doesn't work because the provided SSL certificates don't match the proxy server hostname. Network load balancers, being Layer 4 load balancers, support TCP traffic passthrough, but not SSL termination. Application load balancers, however, do support SSL termination.
+
 ### IAM DB authentication
 
 _neptune-export_ supports exporting from databases that have [IAM database authentication](https://docs.aws.amazon.com/neptune/latest/userguide/iam-auth.html) enabled. Supply the `--use-iam-auth` option with each command. Remember to set the **SERVICE_REGION** environment variable – e.g. `export SERVICE_REGION=us-east-1`.

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/NeptuneExportBaseCommand.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/NeptuneExportBaseCommand.java
@@ -37,6 +37,10 @@ public class NeptuneExportBaseCommand {
     @Once
     protected boolean useIamAuth = false;
 
+    @Option(name = {"--use-ssl"}, description = "Enables connectivity over SSL")
+    @Once
+    protected boolean useSsl = false;
+
     @Option(name = {"--nlb-endpoint"}, description = "Network load balancer endpoint (optional: use only if connecting to an IAM DB enabled Neptune cluster through a network load balancer (NLB) – see https://github.com/aws-samples/aws-dbs-refarch-graph/tree/master/src/connecting-using-a-load-balancer#connecting-to-amazon-neptune-from-clients-outside-the-neptune-vpc-using-aws-network-load-balancer)")
     @Once
     @MutuallyExclusiveWith(tag = "load-balancer")
@@ -53,7 +57,7 @@ public class NeptuneExportBaseCommand {
     protected int loadBalancerPort = 80;
 
     public ConnectionConfig connectionConfig(){
-        return new ConnectionConfig(endpoints, port, networkLoadBalancerEndpoint, applicationLoadBalancerEndpoint, loadBalancerPort, useIamAuth);
+        return new ConnectionConfig(endpoints, port, networkLoadBalancerEndpoint, applicationLoadBalancerEndpoint, loadBalancerPort, useIamAuth, useSsl);
     }
 
     public void setLoggingLevel(){

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/auth/ConnectionConfig.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/auth/ConnectionConfig.java
@@ -23,19 +23,22 @@ public class ConnectionConfig {
     private final String albEndpoint;
     private final int lbPort;
     private final boolean useIamAuth;
+    private final boolean useSsl;
 
     public ConnectionConfig(Collection<String> neptuneEndpoints,
                             int neptunePort,
                             String nlbEndpoint,
                             String albEndpoint,
                             int lbPort,
-                            boolean useIamAuth) {
+                            boolean useIamAuth,
+                            boolean useSsl) {
         this.neptuneEndpoints = neptuneEndpoints;
         this.neptunePort = neptunePort;
         this.nlbEndpoint = nlbEndpoint;
         this.albEndpoint = albEndpoint;
         this.lbPort = lbPort;
         this.useIamAuth = useIamAuth;
+        this.useSsl = useSsl;
     }
 
     public Collection<String> endpoints() {
@@ -58,6 +61,10 @@ public class ConnectionConfig {
 
     public boolean useIamAuth() {
         return useIamAuth;
+    }
+
+    public boolean useSsl() {
+        return useSsl;
     }
 
     public HandshakeRequestConfig handshakeRequestConfig() {

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClient.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClient.java
@@ -33,6 +33,7 @@ public class NeptuneGremlinClient implements AutoCloseable {
     public static NeptuneGremlinClient create(ConnectionConfig connectionConfig, ConcurrencyConfig concurrencyConfig, int batchSize) {
         Cluster.Builder builder = Cluster.build()
                 .port(connectionConfig.port())
+                .enableSsl(connectionConfig.useSsl())
                 .serializer(Serializers.GRYO_V3D0)
                 .maxWaitForConnection(10000)
                 .resultIterationBatchSize(batchSize);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Provide `--use-ssl` option. This will allow connecting to Neptune using SSL. Note that this cannot be used with a network load balancer. If you are using a load balancer you must use SSL termination and have your own SSL certificate on the proxy server. A network load balancer, being a Layer 4 load balancer, doesn't support SSL termination.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
