### PR TITLE
Improvements to exporting Neptune Stream records to Kinesis

### DIFF
--- a/neptune-export/pom.xml
+++ b/neptune-export/pom.xml
@@ -36,6 +36,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-groovy</artifactId>
+            <version>3.4.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
             <version>1.11.307</version>

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/io/KinesisStreamOutputWriter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/io/KinesisStreamOutputWriter.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Future;
 
-public class StreamOutputWriter extends Writer implements OutputWriter {
+public class KinesisStreamOutputWriter extends Writer implements OutputWriter {
 
     private final String streamName;
     private final KinesisProducer kinesisProducer;
@@ -36,7 +36,7 @@ public class StreamOutputWriter extends Writer implements OutputWriter {
 
     List<Future<UserRecordResult>> putFutures = new LinkedList<>();
 
-    public StreamOutputWriter(KinesisConfig kinesisConfig) {
+    public KinesisStreamOutputWriter(KinesisConfig kinesisConfig) {
         this.streamName = kinesisConfig.streamName();
         this.kinesisProducer = kinesisConfig.client();
     }
@@ -47,14 +47,14 @@ public class StreamOutputWriter extends Writer implements OutputWriter {
     }
 
     @Override
-    public void finish() {
+    public void finish(String partitionKey) {
         String s = writer.toString();
 
         if (StringUtils.isNotEmpty(s)) {
 
             try {
                 ByteBuffer data = ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8.name()));
-                putFutures.add(kinesisProducer.addUserRecord(streamName, UUID.randomUUID().toString(), data));
+                putFutures.add(kinesisProducer.addUserRecord(streamName, partitionKey, data));
             } catch (UnsupportedEncodingException e) {
                 throw new RuntimeException(e);
             }
@@ -80,7 +80,7 @@ public class StreamOutputWriter extends Writer implements OutputWriter {
 
     @Override
     public void flush() throws IOException {
-
+        writer.flush();
     }
 
     @Override

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/io/OutputWriter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/io/OutputWriter.java
@@ -16,11 +16,15 @@ import java.io.Writer;
 
 public interface OutputWriter extends AutoCloseable {
 
-    void start();
+    void startCommit();
 
-    void finish(String partitionKey);
+    void endCommit(String partitionKey);
 
     void print(String s);
 
     Writer writer();
+
+    void startOp();
+
+    void endOp();
 }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/io/OutputWriter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/io/OutputWriter.java
@@ -18,7 +18,7 @@ public interface OutputWriter extends AutoCloseable {
 
     void start();
 
-    void finish();
+    void finish(String partitionKey);
 
     void print(String s);
 

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/io/PrintOutputWriter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/io/PrintOutputWriter.java
@@ -13,7 +13,6 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.io;
 
 import java.io.*;
-import java.util.UUID;
 
 public class PrintOutputWriter extends PrintWriter implements OutputWriter {
     public PrintOutputWriter(Writer out) {
@@ -49,12 +48,12 @@ public class PrintOutputWriter extends PrintWriter implements OutputWriter {
     }
 
     @Override
-    public void start() {
+    public void startCommit() {
         // Do nothing
     }
 
     @Override
-    public void finish(String partitionKey) {
+    public void endCommit(String partitionKey) {
         // Do nothing
     }
 
@@ -63,4 +62,13 @@ public class PrintOutputWriter extends PrintWriter implements OutputWriter {
         return this;
     }
 
+    @Override
+    public void startOp() {
+        // Do nothing
+    }
+
+    @Override
+    public void endOp() {
+        // Do nothing
+    }
 }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/io/PrintOutputWriter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/io/PrintOutputWriter.java
@@ -12,9 +12,8 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.io;
 
-import com.amazonaws.services.neptune.io.OutputWriter;
-
 import java.io.*;
+import java.util.UUID;
 
 public class PrintOutputWriter extends PrintWriter implements OutputWriter {
     public PrintOutputWriter(Writer out) {
@@ -55,7 +54,7 @@ public class PrintOutputWriter extends PrintWriter implements OutputWriter {
     }
 
     @Override
-    public void finish() {
+    public void finish(String partitionKey) {
         // Do nothing
     }
 

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/io/Target.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/io/Target.java
@@ -42,7 +42,7 @@ public enum Target {
     stream{
         @Override
         public OutputWriter createOutputWriter(Path filePath, KinesisConfig kinesisConfig) throws IOException {
-            return new StreamOutputWriter(kinesisConfig);
+            return new KinesisStreamOutputWriter(kinesisConfig);
         }
 
         @Override

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/EdgesClient.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/EdgesClient.java
@@ -19,6 +19,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.T;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -26,6 +28,8 @@ import java.util.*;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
 
 public class EdgesClient implements GraphClient<Map<String, Object>> {
+
+    private static final Logger logger = LoggerFactory.getLogger(EdgesClient.class);
 
     private final GraphTraversalSource g;
     private final boolean tokensOnly;
@@ -47,6 +51,8 @@ public class EdgesClient implements GraphClient<Map<String, Object>> {
         GraphTraversal<? extends Element, Map<Object, Object>> t = tokensOnly ?
                 traversal(range, labelsFilter).valueMap(true, "~TOKENS-ONLY") :
                 traversal(range, labelsFilter).valueMap(true);
+
+        logger.info(GremlinQueryDebugger.queryAsString(t));
 
         t.forEachRemaining(m -> {
             try {
@@ -79,6 +85,8 @@ public class EdgesClient implements GraphClient<Map<String, Object>> {
                         ).
                         by(outV().id()).
                         by(inV().id());
+
+        logger.info(GremlinQueryDebugger.queryAsString(t));
 
         traversal.forEachRemaining(p -> {
             try {

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinQueryDebugger.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinQueryDebugger.java
@@ -1,0 +1,10 @@
+package com.amazonaws.services.neptune.propertygraph;
+
+import org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyTranslator;
+
+public class GremlinQueryDebugger {
+
+    public static String queryAsString(Object o){
+        return String.valueOf(new GroovyTranslator.DefaultTypeTranslator().apply("g", o));
+    }
+}

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/NodesClient.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/NodesClient.java
@@ -14,11 +14,15 @@ package com.amazonaws.services.neptune.propertygraph;
 
 import com.amazonaws.services.neptune.propertygraph.io.GraphElementHandler;
 import com.amazonaws.services.neptune.propertygraph.metadata.PropertiesMetadata;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyTranslator;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -27,6 +31,8 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.valueMap;
 
 public class NodesClient implements GraphClient<Map<String, Object>> {
+
+    private static final Logger logger = LoggerFactory.getLogger(NodesClient.class);
 
     private final GraphTraversalSource g;
     private final boolean tokensOnly;
@@ -49,6 +55,8 @@ public class NodesClient implements GraphClient<Map<String, Object>> {
         GraphTraversal<? extends Element, Map<Object, Object>> t = tokensOnly ?
                 traversal(range, labelsFilter).valueMap(true, "~TOKENS-ONLY") :
                 traversal(range, labelsFilter).valueMap(true);
+
+        logger.info(GremlinQueryDebugger.queryAsString(t));
 
         t.forEachRemaining(m -> {
             try {
@@ -73,6 +81,8 @@ public class NodesClient implements GraphClient<Map<String, Object>> {
                         select("x") :
                         valueMap(labelsFilter.getPropertiesForLabels(propertiesMetadata))
                 );
+
+        logger.info(GremlinQueryDebugger.queryAsString(t));
 
         t.forEachRemaining(m -> {
             try {

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/Range.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/Range.java
@@ -30,14 +30,22 @@ public class Range {
     }
 
     public GraphTraversal<? extends Element, ?> applyRange(GraphTraversal<? extends Element, ?> traversal) {
+
+        // Workaround for R12 issue
         if (end == -1) {
-            return traversal;
+            return isEmpty() ? traversal : traversal.skip(-1);
         } else {
-            return traversal.range(start, end);
+            return isEmpty() ? traversal.range(start, end) : traversal.skip(1).range(start, end);
         }
+
+//        if (end == -1) {
+//            return traversal;
+//        } else {
+//            return traversal.range(start, end);
+//        }
     }
 
-    public long difference(){
+    public long difference() {
         return abs(end) - start;
     }
 

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/Range.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/Range.java
@@ -31,18 +31,11 @@ public class Range {
 
     public GraphTraversal<? extends Element, ?> applyRange(GraphTraversal<? extends Element, ?> traversal) {
 
-        // Workaround for R12 issue
         if (end == -1) {
-            return isEmpty() ? traversal : traversal.skip(-1);
+            return traversal;
         } else {
-            return isEmpty() ? traversal.range(start, end) : traversal.skip(1).range(start, end);
+            return traversal.range(start, end);
         }
-
-//        if (end == -1) {
-//            return traversal;
-//        } else {
-//            return traversal.range(start, end);
-//        }
     }
 
     public long difference() {

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/CsvPropertyGraphPrinter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/CsvPropertyGraphPrinter.java
@@ -117,14 +117,14 @@ public class CsvPropertyGraphPrinter implements PropertyGraphPrinter {
     @Override
     public void printStartRow() {
         partitionKey = UUID.randomUUID().toString();
-        writer.start();
+        writer.startCommit();
         commaPrinter.init();
     }
 
     @Override
     public void printEndRow() {
         writer.print(System.lineSeparator());
-        writer.finish(partitionKey);
+        writer.endCommit(partitionKey);
     }
 
     private String formatList(Object value, DataType dataType) {

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/CsvPropertyGraphPrinter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/CsvPropertyGraphPrinter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class CsvPropertyGraphPrinter implements PropertyGraphPrinter {
 
@@ -28,6 +29,7 @@ public class CsvPropertyGraphPrinter implements PropertyGraphPrinter {
     private final CommaPrinter commaPrinter;
     private final boolean includeHeaders;
     private final boolean includeTypeDefinitions;
+    private String partitionKey = UUID.randomUUID().toString();
 
     public CsvPropertyGraphPrinter(OutputWriter writer,
                                    Map<Object, PropertyTypeInfo> metadata,
@@ -114,6 +116,7 @@ public class CsvPropertyGraphPrinter implements PropertyGraphPrinter {
 
     @Override
     public void printStartRow() {
+        partitionKey = UUID.randomUUID().toString();
         writer.start();
         commaPrinter.init();
     }
@@ -121,7 +124,7 @@ public class CsvPropertyGraphPrinter implements PropertyGraphPrinter {
     @Override
     public void printEndRow() {
         writer.print(System.lineSeparator());
-        writer.finish();
+        writer.finish(partitionKey);
     }
 
     private String formatList(Object value, DataType dataType) {

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/JsonPropertyGraphPrinter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/JsonPropertyGraphPrinter.java
@@ -102,7 +102,7 @@ public class JsonPropertyGraphPrinter implements PropertyGraphPrinter {
     @Override
     public void printStartRow() throws IOException {
         partitionKey = UUID.randomUUID().toString();
-        writer.start();
+        writer.startCommit();
         generator.writeStartObject();
     }
 
@@ -110,7 +110,7 @@ public class JsonPropertyGraphPrinter implements PropertyGraphPrinter {
     public void printEndRow() throws IOException {
         generator.flush();
         generator.writeEndObject();
-        writer.finish(partitionKey);
+        writer.endCommit(partitionKey);
     }
 
     @Override

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/JsonPropertyGraphPrinter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/JsonPropertyGraphPrinter.java
@@ -21,12 +21,14 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class JsonPropertyGraphPrinter implements PropertyGraphPrinter {
 
     private final OutputWriter writer;
     private final JsonGenerator generator;
     private final Map<Object, PropertyTypeInfo> metadata;
+    private String partitionKey = UUID.randomUUID().toString();
 
     public JsonPropertyGraphPrinter(OutputWriter writer, JsonGenerator generator, Map<Object, PropertyTypeInfo> metadata) throws IOException {
         this.writer = writer;
@@ -99,6 +101,7 @@ public class JsonPropertyGraphPrinter implements PropertyGraphPrinter {
 
     @Override
     public void printStartRow() throws IOException {
+        partitionKey = UUID.randomUUID().toString();
         writer.start();
         generator.writeStartObject();
     }
@@ -107,7 +110,7 @@ public class JsonPropertyGraphPrinter implements PropertyGraphPrinter {
     public void printEndRow() throws IOException {
         generator.flush();
         generator.writeEndObject();
-        writer.finish();
+        writer.finish(partitionKey);
     }
 
     @Override

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/PropertyGraphExportFormat.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/PropertyGraphExportFormat.java
@@ -82,7 +82,6 @@ public enum PropertyGraphExportFormat implements FileExtension {
         @Override
         PropertyGraphPrinter createPrinter(OutputWriter writer, Map<Object, PropertyTypeInfo> metadata, boolean includeTypeDefinitions) throws IOException {
             JsonGenerator generator = new JsonFactory().createGenerator(writer.writer());
-            generator.setPrettyPrinter(new MinimalPrettyPrinter(System.lineSeparator()));
             return new NeptuneStreamsJsonPropertyGraphPrinter(writer, generator, metadata);
         }
 

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/EnhancedNQuadsWriter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/EnhancedNQuadsWriter.java
@@ -19,6 +19,8 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.nquads.NQuadsWriter;
 
+import java.util.UUID;
+
 public class EnhancedNQuadsWriter extends NQuadsWriter {
 
 
@@ -41,7 +43,7 @@ public class EnhancedNQuadsWriter extends NQuadsWriter {
 
         writer.start();
         super.handleStatement(statement);
-        writer.finish();
+        writer.finish(UUID.randomUUID().toString());
 
         status.update();
     }
@@ -50,6 +52,6 @@ public class EnhancedNQuadsWriter extends NQuadsWriter {
     public void handleNamespace(String prefix, String name) {
         writer.start();
         super.handleNamespace(prefix, name);
-        writer.finish();
+        writer.finish(UUID.randomUUID().toString());
     }
 }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/EnhancedNQuadsWriter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/EnhancedNQuadsWriter.java
@@ -41,17 +41,17 @@ public class EnhancedNQuadsWriter extends NQuadsWriter {
         prefixes.parse(statement.getObject().stringValue(), this);
         prefixes.parse(statement.getContext().stringValue(), this);
 
-        writer.start();
+        writer.startCommit();
         super.handleStatement(statement);
-        writer.finish(UUID.randomUUID().toString());
+        writer.endCommit(UUID.randomUUID().toString());
 
         status.update();
     }
 
     @Override
     public void handleNamespace(String prefix, String name) {
-        writer.start();
+        writer.startCommit();
         super.handleNamespace(prefix, name);
-        writer.finish(UUID.randomUUID().toString());
+        writer.endCommit(UUID.randomUUID().toString());
     }
 }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/EnhancedTurtleWriter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/EnhancedTurtleWriter.java
@@ -42,9 +42,9 @@ public class EnhancedTurtleWriter extends TurtleWriter {
         prefixes.parse(statement.getObject().stringValue(), this);
         prefixes.parse(statement.getContext().stringValue(), this);
 
-        writer.start();
+        writer.startCommit();
         super.handleStatement(statement);
-        writer.finish(UUID.randomUUID().toString());
+        writer.endCommit(UUID.randomUUID().toString());
 
         status.update();
     }
@@ -52,8 +52,8 @@ public class EnhancedTurtleWriter extends TurtleWriter {
     @Override
     protected void writeNamespace(String prefix, String name)
             throws IOException {
-        writer.start();
+        writer.startCommit();
         super.writeNamespace(prefix, name);
-        writer.finish(UUID.randomUUID().toString());
+        writer.endCommit(UUID.randomUUID().toString());
     }
 }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/EnhancedTurtleWriter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/EnhancedTurtleWriter.java
@@ -20,6 +20,7 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.turtle.TurtleWriter;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class EnhancedTurtleWriter extends TurtleWriter {
 
@@ -43,7 +44,7 @@ public class EnhancedTurtleWriter extends TurtleWriter {
 
         writer.start();
         super.handleStatement(statement);
-        writer.finish();
+        writer.finish(UUID.randomUUID().toString());
 
         status.update();
     }
@@ -53,6 +54,6 @@ public class EnhancedTurtleWriter extends TurtleWriter {
             throws IOException {
         writer.start();
         super.writeNamespace(prefix, name);
-        writer.finish();
+        writer.finish(UUID.randomUUID().toString());
     }
 }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/NeptuneStreamsJsonNQuadsWriter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/NeptuneStreamsJsonNQuadsWriter.java
@@ -85,7 +85,7 @@ public class NeptuneStreamsJsonNQuadsWriter implements RDFWriter {
     public void handleStatement(Statement statement) throws RDFHandlerException {
 
         try {
-            outputWriter.start();
+            outputWriter.startCommit();
 
             generator.writeStartObject();
 
@@ -111,7 +111,7 @@ public class NeptuneStreamsJsonNQuadsWriter implements RDFWriter {
             generator.writeEndObject();
             generator.flush();
 
-            outputWriter.finish(UUID.randomUUID().toString());
+            outputWriter.endCommit(UUID.randomUUID().toString());
 
             status.update();
 

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/NeptuneStreamsJsonNQuadsWriter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/rdf/io/NeptuneStreamsJsonNQuadsWriter.java
@@ -16,7 +16,6 @@ import com.amazonaws.services.neptune.io.OutputWriter;
 import com.amazonaws.services.neptune.io.Status;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.*;
 import org.eclipse.rdf4j.rio.nquads.NQuadsWriter;
@@ -25,6 +24,7 @@ import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Collection;
+import java.util.UUID;
 
 public class NeptuneStreamsJsonNQuadsWriter implements RDFWriter {
 
@@ -35,9 +35,7 @@ public class NeptuneStreamsJsonNQuadsWriter implements RDFWriter {
     public NeptuneStreamsJsonNQuadsWriter(OutputWriter outputWriter) {
         this.outputWriter = outputWriter;
         try {
-            this.generator = new JsonFactory().
-                    createGenerator(outputWriter.writer()).
-                    setPrettyPrinter(new MinimalPrettyPrinter(System.lineSeparator()));
+            this.generator = new JsonFactory().createGenerator(outputWriter.writer());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -105,14 +103,15 @@ public class NeptuneStreamsJsonNQuadsWriter implements RDFWriter {
             nQuadsWriter.startRDF();
             nQuadsWriter.handleStatement(statement);
             nQuadsWriter.endRDF();
-            generator.writeString(stringWriter.toString());
+            generator.writeString(stringWriter.toString().replace(System.lineSeparator(), ""));
 
             generator.writeEndObject();
 
             generator.writeStringField("op", "ADD");
             generator.writeEndObject();
+            generator.flush();
 
-            outputWriter.finish();
+            outputWriter.finish(UUID.randomUUID().toString());
 
             status.update();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

All ops for a commit for Gremlin submitted as a single JSON array record to Kinesis to preserve unit of work semantics necessary for ElasticSearch index population scripts.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
