### PR TITLE
use wss:// instead of ws://

### DIFF
--- a/drop-graph/drop-graph.py
+++ b/drop-graph/drop-graph.py
@@ -98,7 +98,7 @@ pending_work = Queue()
 # Location of the Neptune endpoint and port
 writer = os.environ["NEPTUNE_WRITER"]
 port = os.environ["NEPTUNE_PORT"]
-neptune_gremlin_endpoint = 'ws://' + writer + ':' + port + '/gremlin'
+neptune_gremlin_endpoint = 'wss://' + writer + ':' + port + '/gremlin'
 
 # Obtain a graph traversal source for the remote endpoint.
 graph=Graph()


### PR DESCRIPTION
*Issue #, if available:*
Unable to connect to Neptune writer over ws://

*Description of changes:*
Changed socket url to use secure websocket (wss://) instead of ws://

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
