### PR TITLE
Support batch inserts/upserts in Glue jobs, with retries.

### DIFF
--- a/neptune-python-utils/build.sh
+++ b/neptune-python-utils/build.sh
@@ -10,13 +10,14 @@ source temp/bin/activate
 cd temp
 pip install gremlinpython
 pip install requests
+pip install backoff
 cd lib/python3.8/site-packages
 rm -rf certifi-*
 rm -rf easy_install.py
 rm -rf six.py
 cp -r ../../../../*.py .
 cp -r ../../../../neptune_python_utils .
-zip -r neptune_python_utils.zip neptune_python_utils gremlin_python aenum isodate tornado
+zip -r neptune_python_utils.zip neptune_python_utils gremlin_python aenum isodate tornado backoff
 mv neptune_python_utils.zip ../../../../target/neptune_python_utils.zip
 deactivate
 popd

--- a/neptune-python-utils/neptune_python_utils/glue_gremlin_client.py
+++ b/neptune-python-utils/neptune_python_utils/glue_gremlin_client.py
@@ -13,6 +13,7 @@
 # and limitations under the License.
 
 import sys
+import backoff
 
 from pyspark.sql.functions import lit
 from pyspark.sql.functions import format_string
@@ -33,9 +34,20 @@ class GlueGremlinClient:
         self.gremlin_utils = GremlinUtils(endpoints)
         
         GremlinUtils.init_statics(globals())
+        
+    def not_cme(e):
+        return '"code":"ConcurrentModificationException"' not in str(e)
+     
+    @backoff.on_exception(backoff.expo,
+                          GremlinServerError,
+                          max_tries=5,
+                          giveup=not_cme)
+    def retry_query(self, query):
+        q = query
+        q.next()
 
         
-    def add_vertices(self, label):
+    def add_vertices(self, label, batch_size=1):
         """Adds a vertex with the supplied label for each row in a DataFrame partition.
         If the DataFrame contains an '~id' column, the values in this column will be treated as user-supplied IDs for the new vertices.
         If the DataFrame does not have an '~id' column, Neptune will autogenerate a UUID for each vertex. 
@@ -44,29 +56,37 @@ class GlueGremlinClient:
         >>> dynamicframe.toDF().foreachPartition(neptune.add_vertices('Product'))
         """
         def add_vertices_for_label(rows):
-            try:
-                conn = self.gremlin_utils.remote_connection()
-                g = self.gremlin_utils.traversal_source(connection=conn) 
-                for row in rows:
-                    entries = row.asDict()
-                    traversal = g.addV(label)
-                    for key, value in entries.items():
-                        key = key.split(':')[0]
-                        if key == '~id':
-                            traversal.property(id, value)
-                        elif key == '~label':
-                            pass
-                        else:
-                            traversal.property(key, value)
-                    traversal.next() 
-                conn.close()
-            except GremlinServerError as err:
-                print("Neptune error: {0}".format(err))
-            except:
-                print("Unexpected error:", sys.exc_info()[0])
+
+            conn = self.gremlin_utils.remote_connection()
+            g = self.gremlin_utils.traversal_source(connection=conn)
+            
+            t = g
+            i = 0
+            for row in rows:
+                entries = row.asDict()
+                t = t.addV(label)
+                for key, value in entries.items():
+                    key = key.split(':')[0]
+                    if key == '~id':
+                        t = t.property(id, value)
+                    elif key == '~label':
+                        pass
+                    else:
+                        t = t.property(key, value)
+                i += 1
+                if i == batch_size:
+                    self.retry_query(t)
+                    t = g
+                    i = 0
+            if i > 0:
+                self.retry_query(t)
+
+            conn.close()
+
         return add_vertices_for_label
+
         
-    def upsert_vertices(self, label):
+    def upsert_vertices(self, label, batch_size=1):
         """Conditionally adds vertices for the rows in a DataFrame partition using the Gremlin coalesce() idiom.
         The DataFrame must contain an '~id' column. 
         
@@ -74,29 +94,37 @@ class GlueGremlinClient:
         >>> dynamicframe.toDF().foreachPartition(neptune.upsert_vertices('Product'))
         """
         def upsert_vertices_for_label(rows):
-            try:
-                conn = self.gremlin_utils.remote_connection()
-                g = self.gremlin_utils.traversal_source(connection=conn) 
-                for row in rows:
-                    entries = row.asDict()
-                    create_traversal = __.addV(label)
-                    for key, value in entries.items():
-                        key = key.split(':')[0]
-                        if key == '~id':
-                            create_traversal.property(id, value)
-                        elif key == '~label':
-                            pass
-                        else:
-                            create_traversal.property(key, value)
-                    g.V(entries['~id']).fold().coalesce(__.unfold(), create_traversal).next() 
-                conn.close()
-            except GremlinServerError as err:
-                print("Neptune error: {0}".format(err))
-            except:
-                print("Unexpected error:", sys.exc_info()[0])
+
+            conn = self.gremlin_utils.remote_connection()
+            g = self.gremlin_utils.traversal_source(connection=conn) 
+            
+            t = g
+            i = 0
+            for row in rows:
+                entries = row.asDict()
+                create_traversal = __.addV(label)
+                for key, value in entries.items():
+                    key = key.split(':')[0]
+                    if key == '~id':
+                        create_traversal = create_traversal.property(id, value)
+                    elif key == '~label':
+                        pass
+                    else:
+                        create_traversal = create_traversal.property(key, value)
+                t = t.V(entries['~id']).fold().coalesce(__.unfold(), create_traversal)
+                i += 1
+                if i == batch_size:
+                    self.retry_query(t)
+                    t = g
+                    i = 0
+            if i > 0:
+                self.retry_query(t)
+                        
+            conn.close()
+
         return upsert_vertices_for_label
     
-    def add_edges(self, label):
+    def add_edges(self, label, batch_size=1):
         """Adds an edge with the supplied label for each row in a DataFrame partition.
         If the DataFrame contains an '~id' column, the values in this column will be treated as user-supplied IDs for the new edges.
         If the DataFrame does not have an '~id' column, Neptune will autogenerate a UUID for each edge. 
@@ -105,25 +133,32 @@ class GlueGremlinClient:
         >>> dynamicframe.toDF().foreachPartition(neptune.add_edges('ORDER_DETAIL'))
         """
         def add_edges_for_label(rows):
-            try:
-                conn = self.gremlin_utils.remote_connection()
-                g = self.gremlin_utils.traversal_source(connection=conn) 
-                for row in rows:
-                    entries = row.asDict()
-                    traversal = g.V(row['~from']).addE(label).to(V(row['~to'])).property(id, row['~id'])
-                    for key, value in entries.items():
-                        key = key.split(':')[0]
-                        if key not in ['~id', '~from', '~to', '~label']:
-                            traversal.property(key, value)
-                    traversal.next() 
-                conn.close()
-            except GremlinServerError as err:
-                print("Neptune error: {0}".format(err))
-            except:
-                print("Unexpected error:", sys.exc_info()[0])
+
+            conn = self.gremlin_utils.remote_connection()
+            g = self.gremlin_utils.traversal_source(connection=conn) 
+            
+            t = g
+            i = 0
+            for row in rows:
+                entries = row.asDict()
+                t = t.V(entries['~from']).addE(label).to(V(entries['~to'])).property(id, entries['~id'])
+                for key, value in entries.items():
+                    key = key.split(':')[0]
+                    if key not in ['~id', '~from', '~to', '~label']:
+                        t = t.property(key, value)
+                i += 1
+                if i == batch_size:
+                    self.retry_query(t)
+                    t = g
+                    i = 0
+            if i > 0:
+                self.retry_query(t) 
+                
+            conn.close()
+            
         return add_edges_for_label
         
-    def upsert_edges(self, label):
+    def upsert_edges(self, label, batch_size=1):
         """Conditionally adds edges for the rows in a DataFrame partition using the Gremlin coalesce() idiom.
         The DataFrame must contain '~id', '~from', '~to' and '~label' columns. 
         
@@ -131,20 +166,28 @@ class GlueGremlinClient:
         >>> dynamicframe.toDF().foreachPartition(neptune.upsert_edges('ORDER_DETAIL'))
         """
         def add_edges_for_label(rows):
-            try:
-                conn = self.gremlin_utils.remote_connection()
-                g = self.gremlin_utils.traversal_source(connection=conn) 
-                for row in rows:
-                    entries = row.asDict()
-                    create_traversal = __.V(row['~from']).addE(label).to(V(row['~to'])).property(id, row['~id'])
-                    for key, value in entries.items():
-                        key = key.split(':')[0]
-                        if key not in ['~id', '~from', '~to', '~label']:
-                            create_traversal.property(key, value)
-                    g.E(entries['~id']).fold().coalesce(__.unfold(), create_traversal).next()
-                conn.close()
-            except GremlinServerError as err:
-                print("Neptune error: {0}".format(err))
-            except:
-                print("Unexpected error:", sys.exc_info()[0])
+
+            conn = self.gremlin_utils.remote_connection()
+            g = self.gremlin_utils.traversal_source(connection=conn) 
+            
+            t = g
+            i = 0
+            for row in rows:
+                entries = row.asDict()
+                create_traversal = __.V(entries['~from']).addE(label).to(V(entries['~to'])).property(id, entries['~id'])
+                for key, value in entries.items():
+                    key = key.split(':')[0]
+                    if key not in ['~id', '~from', '~to', '~label']:
+                        create_traversal.property(key, value)
+                t = t.V(entries['~from']).outE(label).hasId(entries['~id']).fold().coalesce(__.unfold(), create_traversal)
+                i += 1
+                if i == batch_size:
+                    self.retry_query(t)
+                    t = g
+                    i = 0
+            if i > 0:
+                self.retry_query(t)
+                
+            conn.close()
+
         return add_edges_for_label

--- a/neptune-python-utils/neptune_python_utils/glue_neptune_connection_info.py
+++ b/neptune-python-utils/neptune_python_utils/glue_neptune_connection_info.py
@@ -12,9 +12,8 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-import sys, boto3, os, uuid
+import sys, boto3
 from urllib.parse import urlparse
-from botocore.credentials import Credentials
 from neptune_python_utils.endpoints import Endpoints
 
 class GlueNeptuneConnectionInfo:
@@ -37,7 +36,7 @@ class GlueNeptuneConnectionInfo:
         
         'jdbc:wss://my-neptune-cluster.us-east-1.neptune.amazonaws.com:8182/gremlin'
         
-        – this method will return:
+        – this method will return:
         
         'wss://my-neptune-cluster.us-east-1.neptune.amazonaws.com:8182/gremlin' 
         
@@ -53,18 +52,4 @@ class GlueNeptuneConnectionInfo:
         host = netloc_parts[0]
         port = netloc_parts[1]
         
-        sts = boto3.client('sts', region_name=self.region)
-        
-        role = sts.assume_role(
-            RoleArn=self.role_arn,
-            RoleSessionName=uuid.uuid4().hex,
-            DurationSeconds=3600
-        )
-        
-        credentials = Credentials(
-            access_key=role['Credentials']['AccessKeyId'], 
-            secret_key=role['Credentials']['SecretAccessKey'], 
-            token=role['Credentials']['SessionToken'])
-        
-        return Endpoints(neptune_endpoint=host, neptune_port=port, region_name=self.region, credentials=credentials)
-        
+        return Endpoints(neptune_endpoint=host, neptune_port=port, region_name=self.region, role_arn=self.role_arn)

--- a/neptune-python-utils/readme.md
+++ b/neptune-python-utils/readme.md
@@ -30,6 +30,8 @@ The following query uses `NEPTUNE_CLUSTER_ENDPOINT` and `NEPTUNE_CLUSTER_PORT` e
 ```
 from neptune_python_utils.gremlin_utils import GremlinUtils
 
+GremlinUtils.init_statics(globals())
+
 gremlin_utils = GremlinUtils()
 
 conn = gremlin_utils.remote_connection()
@@ -45,6 +47,8 @@ If you want to supply your own endpoint information, you can use `neptune_endpoi
 ```
 from neptune_python_utils.gremlin_utils import GremlinUtils
 from neptune_python_utils.endpoints import Endpoints
+
+GremlinUtils.init_statics(globals())
 
 endpoints = Endpoints(neptune_endpoint='demo.cluster-111222333.eu-west-2.neptune.amazonaws.com')
 gremlin_utils = GremlinUtils(endpoints)
@@ -63,6 +67,8 @@ If you want to supply your own credentials, you can supply a `Credentials` objec
 from neptune_python_utils.gremlin_utils import GremlinUtils
 from neptune_python_utils.endpoints import Endpoints
 import boto3
+
+GremlinUtils.init_statics(globals())
 
 session = boto3.session.Session()
 credentials = session.get_credentials()
@@ -87,6 +93,8 @@ The following code creates a sessioned client. All requests sent using this clie
 
 ```
 from neptune_python_utils.gremlin_utils import GremlinUtils
+
+GremlinUtils.init_statics(globals())
 
 gremlin_utils = GremlinUtils()
 

--- a/neptune-python-utils/readme.md
+++ b/neptune-python-utils/readme.md
@@ -253,6 +253,8 @@ print(g.V().limit(10).valueMap().toList())
 conn.close()
 ```
 
+Credentials generated via `sts.assume_role()` last an hour. If you have a long running Glue job, you may want to create a `RefreshableCredentials` object. See [this article](https://dev.to/li_chastina/auto-refresh-aws-tokens-using-iam-role-and-boto3-2cjf) for more details.
+
 If using a `GlueNeptuneConnectionInfo` object to get Neptune connection information from the Glue Data Catalog, simply pass the region and Neptune access IAM role ARN to the `GlueNeptuneConnectionInfo` constructor:
 
 ```

--- a/neptune-python-utils/readme.md
+++ b/neptune-python-utils/readme.md
@@ -282,7 +282,119 @@ role_arn = args['CONNECT_TO_NEPTUNE_ROLE_ARN']
 endpoints = GlueNeptuneConnectionInfo(region, role_arn).neptune_endpoints('neptune-db')
 ```
 
-### Examples
+### Using neptune-python-utils to insert or upsert data from an AWS Glue job
+
+The code below, taken from the sample Glue job [export-from-mysql-to-neptune.py](https://github.com/aws-samples/amazon-neptune-samples/blob/master/gremlin/glue-neptune/glue-jobs/mysql-neptune/export-from-mysql-to-neptune.py), shows extracting data from several tables in an RDBMS, formatting the dynamic frame columns according to the Neptune bulk load CSV column headings format, and then bulk loading direct into Neptune.
+
+Parallel inserts and upserts can sometimes trigger a `ConcurrentModifcationException`. _neptune-python-utils_ will attempt 5 retries for each batch should such exceptions occur. 
+
+```
+import sys, boto3, os
+
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+from awsglue.transforms import ApplyMapping
+from awsglue.transforms import RenameField
+from awsglue.transforms import SelectFields
+from awsglue.dynamicframe import DynamicFrame
+from pyspark.sql.functions import lit
+from pyspark.sql.functions import format_string
+from gremlin_python import statics
+from gremlin_python.structure.graph import Graph
+from gremlin_python.process.graph_traversal import __
+from gremlin_python.process.strategies import *
+from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+from gremlin_python.process.traversal import *
+from neptune_python_utils.glue_neptune_connection_info import GlueNeptuneConnectionInfo
+from neptune_python_utils.glue_gremlin_client import GlueGremlinClient
+from neptune_python_utils.glue_gremlin_csv_transforms import GlueGremlinCsvTransforms
+from neptune_python_utils.endpoints import Endpoints
+from neptune_python_utils.gremlin_utils import GremlinUtils
+
+args = getResolvedOptions(sys.argv, ['JOB_NAME', 'DATABASE_NAME', 'NEPTUNE_CONNECTION_NAME', 'AWS_REGION', 'CONNECT_TO_NEPTUNE_ROLE_ARN'])
+
+sc = SparkContext()
+glueContext = GlueContext(sc)
+ 
+job = Job(glueContext)
+job.init(args['JOB_NAME'], args)
+
+database = args['DATABASE_NAME']
+product_table = 'salesdb_product'
+product_category_table = 'salesdb_product_category'
+supplier_table = 'salesdb_supplier'
+
+# Create Gremlin client
+
+gremlin_endpoints = GlueNeptuneConnectionInfo(args['AWS_REGION'], args['CONNECT_TO_NEPTUNE_ROLE_ARN']).neptune_endpoints(args['NEPTUNE_CONNECTION_NAME'])
+gremlin_client = GlueGremlinClient(gremlin_endpoints)
+
+# Create Product vertices
+
+print("Creating Product vertices...")
+
+# 1. Get data from source SQL database
+datasource0 = glueContext.create_dynamic_frame.from_catalog(database = database, table_name = product_table, transformation_ctx = "datasource0")
+datasource1 = glueContext.create_dynamic_frame.from_catalog(database = database, table_name = product_category_table, transformation_ctx = "datasource1")
+datasource2 = datasource0.join( ["CATEGORY_ID"],["CATEGORY_ID"], datasource1, transformation_ctx = "join")
+
+# 2. Map fields to bulk load CSV column headings format
+applymapping1 = ApplyMapping.apply(frame = datasource2, mappings = [("NAME", "string", "name:String", "string"), ("UNIT_PRICE", "decimal(10,2)", "unitPrice", "string"), ("PRODUCT_ID", "int", "productId", "int"), ("QUANTITY_PER_UNIT", "int", "quantityPerUnit:Int", "int"), ("CATEGORY_ID", "int", "category_id", "int"), ("SUPPLIER_ID", "int", "supplierId", "int"), ("CATEGORY_NAME", "string", "category:String", "string"), ("DESCRIPTION", "string", "description:String", "string"), ("IMAGE_URL", "string", "imageUrl:String", "string")], transformation_ctx = "applymapping1")
+
+# 3. Append prefixes to values in ID columns (ensures vertices for diffferent types have unique IDs across graph)
+applymapping1 = GlueGremlinCsvTransforms.create_prefixed_columns(applymapping1, [('~id', 'productId', 'p'),('~to', 'supplierId', 's')])
+
+# 4. Select fields for upsert
+selectfields1 = SelectFields.apply(frame = applymapping1, paths = ["~id", "name:String", "category:String", "description:String", "unitPrice", "quantityPerUnit:Int", "imageUrl:String"], transformation_ctx = "selectfields1")
+
+# 5. Upsert batches of vertices
+selectfields1.toDF().foreachPartition(gremlin_client.upsert_vertices('Product', batch_size=100))
+
+# Create Supplier vertices
+
+print("Creating Supplier vertices...")
+
+# 1. Get data from source SQL database
+datasource3 = glueContext.create_dynamic_frame.from_catalog(database = database, table_name = supplier_table, transformation_ctx = "datasource3")
+
+# 2. Map fields to bulk load CSV column headings format
+applymapping2 = ApplyMapping.apply(frame = datasource3, mappings = [("COUNTRY", "string", "country:String", "string"), ("ADDRESS", "string", "address:String", "string"), ("NAME", "string", "name:String", "string"), ("STATE", "string", "state:String", "string"), ("SUPPLIER_ID", "int", "supplierId", "int"), ("CITY", "string", "city:String", "string"), ("PHONE", "string", "phone:String", "string")], transformation_ctx = "applymapping1")
+
+# 3. Append prefixes to values in ID columns (ensures vertices for diffferent types have unique IDs across graph)
+applymapping2 = GlueGremlinCsvTransforms.create_prefixed_columns(applymapping2, [('~id', 'supplierId', 's')])
+
+# 4. Select fields for upsert
+selectfields3 = SelectFields.apply(frame = applymapping2, paths = ["~id", "country:String", "address:String", "city:String", "phone:String", "name:String", "state:String"], transformation_ctx = "selectfields3")
+
+# 5. Upsert batches of vertices
+selectfields3.toDF().foreachPartition(gremlin_client.upsert_vertices('Supplier', batch_size=100))
+
+# SUPPLIER edges
+
+print("Creating SUPPLIER edges...")
+
+# 1. Reuse existing DF, but rename ~id column to ~from
+applymapping1 = RenameField.apply(applymapping1, "~id", "~from")
+
+# 2. Create unique edge IDs
+applymapping1 = GlueGremlinCsvTransforms.create_edge_id_column(applymapping1, '~from', '~to')
+
+# 3. Select fields for upsert
+selectfields2 = SelectFields.apply(frame = applymapping1, paths = ["~id", "~from", "~to"], transformation_ctx = "selectfields2")
+
+# 4. Upsert batches of edges
+selectfields2.toDF().foreachPartition(gremlin_client.upsert_edges('SUPPLIER', batch_size=100))
+
+# End
+
+job.commit()
+
+print("Done")
+```
+
+### Further Examples
 
 See [Migrating from MySQL to Amazon Neptune using AWS Glue](https://github.com/aws-samples/amazon-neptune-samples/tree/master/gremlin/glue-neptune).
  


### PR DESCRIPTION
*Issue #, if available:* 33, 53

*Description of changes:* Previously, insert/upsert operations in Glue jobs proceeded one vertex or edge at a time. Now they can be submitted in batches, thereby improving throughput. (Batch size is 1, by default, for backwards compatability). Operations will retry up to 5 times if a ConcurrentModifcationException occurs.

This PR also allows for IAM credentials to be refreshed periodically in long-running Glue jobs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
