### PR TITLE
Always format lists as lists when printing JSON

### DIFF
--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/JsonPropertyGraphPrinter.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/JsonPropertyGraphPrinter.java
@@ -58,19 +58,13 @@ public class JsonPropertyGraphPrinter implements PropertyGraphPrinter {
 
                 Object value = properties.get(key);
 
-                if (isList(value)) {
+                if (isList(value) || propertyTypeInfo.isMultiValue()) {
                     List<?> values = (List<?>) value;
-                    if (values.size() > 1) {
-                        generator.writeFieldName(formattedKey);
-                        generator.writeStartArray();
-                        for (Object v : values) {
-                            dataType.printTo(generator, v);
-                        }
-                        generator.writeEndArray();
-                    } else {
-                        dataType.printTo(generator, formattedKey, values.get(0));
+                    generator.writeArrayFieldStart(formattedKey);
+                    for (Object v : values) {
+                        dataType.printTo(generator, v);
                     }
-
+                    generator.writeEndArray();
                 } else {
                     dataType.printTo(generator, formattedKey, value);
                 }

--- a/neptune-export/src/test/java/com/amazonaws/services/neptune/propertygraph/io/JsonPropertyGraphPrinterTest.java
+++ b/neptune-export/src/test/java/com/amazonaws/services/neptune/propertygraph/io/JsonPropertyGraphPrinterTest.java
@@ -13,6 +13,11 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.propertygraph.io;
 
 import com.amazonaws.services.neptune.io.PrintOutputWriter;
+import com.amazonaws.services.neptune.propertygraph.metadata.DataType;
+import com.amazonaws.services.neptune.propertygraph.metadata.PropertyTypeInfo;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Test;
 
 import java.io.StringWriter;
@@ -36,5 +41,50 @@ public class JsonPropertyGraphPrinterTest {
         assertEquals(
                 "{\"~id\":\"edge-id\",\"~label\":\"edge-label\",\"~from\":\"from-id\",\"~to\":\"to-id\"}",
                 stringWriter.toString());
+    }
+
+    @Test
+    public void shouldPrintEmptyListAsList() throws Exception {
+        StringWriter stringWriter = new StringWriter();
+        PropertyTypeInfo emptyList = new PropertyTypeInfo("empty-list", DataType.String, true);
+        HashMap<Object, PropertyTypeInfo>  propTypeInfo = new HashMap<Object, PropertyTypeInfo>() {{
+            put("empty-list", emptyList);
+        }};
+
+        HashMap<String, List<String>> props = new HashMap<String, List<String>>() {{
+            put("empty-list", new ArrayList<String>());
+        }};
+        try (PropertyGraphPrinter propertyGraphPrinter = PropertyGraphExportFormat.json.createPrinter(new PrintOutputWriter(stringWriter), propTypeInfo, true)) {
+            propertyGraphPrinter.printStartRow();
+            propertyGraphPrinter.printProperties(props);
+            propertyGraphPrinter.printEndRow();
+        }
+
+        assertEquals(
+            "{\"empty-list\":[]}",
+            stringWriter.toString());
+    }
+
+    @Test
+    public void shouldPrintSingleElementListAsList() throws Exception {
+        StringWriter stringWriter = new StringWriter();
+        PropertyTypeInfo singleList = new PropertyTypeInfo("single-list", DataType.String, true);
+        HashMap<Object, PropertyTypeInfo>  propTypeInfo = new HashMap<Object, PropertyTypeInfo>() {{
+            put("single-list", singleList);
+        }};
+
+        ArrayList<String> elems = new ArrayList<String>() {{ add("the_element"); }};
+        HashMap<String, List<String>> props = new HashMap<String, List<String>>() {{
+            put("single-list", elems);
+        }};
+        try (PropertyGraphPrinter propertyGraphPrinter = PropertyGraphExportFormat.json.createPrinter(new PrintOutputWriter(stringWriter), propTypeInfo, true)) {
+            propertyGraphPrinter.printStartRow();
+            propertyGraphPrinter.printProperties(props);
+            propertyGraphPrinter.printEndRow();
+        }
+
+        assertEquals(
+            "{\"single-list\":[\"the_element\"]}",
+            stringWriter.toString());
     }
 }


### PR DESCRIPTION
Changes JsonPropertyGraphPrinter so that empty lists and single-element
lists are formatted as lists.

Before, the tool crashed on an empty list, and a single-element list was printed as "the_element".

After this change, the tool prints `[]` for an empty list and `[the_element]` for a single-element list.

*Issue #, if available:*

*Description of changes:* Remove a special case in JsonPropertyGraphPrinter that caused neptune-export to crash when writing an empty list as part of the results, and to print single-element lists as though they were single values.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
