### PR TITLE
Csv gremlin updates

### DIFF
--- a/csv-gremlin/README.md
+++ b/csv-gremlin/README.md
@@ -8,12 +8,14 @@ This folder contains the code defining a `NeptuneCSVReader` class. The class is 
 rules and generate Gremlin steps from that data.  Those Gremlin steps can then be used to load the data into any TinkerPop compliant graph that allows for user defined Vertex and Edge IDs.
 
 The tool can detect and handle both the vertex and edge CSV file formats. It
-recognizes the Neptune type specifiers, such as `age:Int` and defaults to String
-if none is provided in a column header.  It also handles rows containing sparse data such as `,,,`.
+recognizes the Neptune type specifiers, such as `age:Int` and `birthday:Date`. If no type mofier is specified in the column header, a type of `String`
+is assumed.  It also handles rows containing sparse data such as `,,,`.
 
 The tool also allows you to specify the batch size for vertices and edges. The
 default is set to 10 for each currently. Batching allows multiple vertices or
 edges, along with their properties, to be added in a single Gremlin query. This is often more efficient than loading them one at a time.
+
+For CSV files containing vertices, the special column headers `~id` and `~label` and their respective values are expected to be present. However, if `~label` is not present a default vertex lable of 'vertex' will be used. For CSV files containing edges all of the following special columns are expected to be present:  `~id`, `~label`, `~from`, `~to` and a value is expected for each in every row.
 
 Gremlin steps that represent the data in the CSV are written to `stdout`.
 
@@ -22,9 +24,6 @@ Gremlin steps that represent the data in the CSV are written to `stdout`.
 Currently the tool does not support cardinality column headers such as
 `age:Int(single)`. Likewise lists of values declared using the `[]` column
 header modifier are not supported.
-
-In this initial version none of the special column headers are allowed to
-be omitted. Those being (`~id`, `~label`, `~from`, `~to`).
 
 ### Running the tool
 
@@ -37,18 +36,32 @@ Where `my-csvfile.csv` is the name of the file to be processed. There are some c
 ```
  python csv-gremlin.py  -vb 20 -eb 20 test.csv
 ```
+
+For columns that contain `Date` values you can choose to have the values used as-is and output in the form `datetime(<the original date string>)` in the Gremlin query or converted to the Java Date form of `new Date(<original date converted to an epoch offset>)`. The `-use_java_dates` argument should be specified if Java format date conversions are required. Further, if dates in the CSV file do not include Time Zone information you can choose to have them treated as local time or as UTC. To specify UTC time as the default use the `assume_utc` argument.
+
+By default all rows of  the CSV file will be processed. To process less rows you can use the `rows` argument to specify a maximum number of rows to process.
+
 The help can always be displayed using the `-h` or `--help` command line arguments.
 ```
-$ python csv-gremlin.py --help
-usage: csv-gremlin.py [-h] [-v] [-vb VB] [-eb EB] [-java_dates] csvfile
+$ python csv-gremlin.py -h
+usage: csv-gremlin.py [-h] [-v] [-vb VB] [-eb EB] [-java_dates] [-assume_utc]
+                      [-rows ROWS]
+                      csvfile
 
 positional arguments:
-  csvfile        the name of the CSV file to process
+  csvfile        The name of the CSV file to process
 
 optional arguments:
   -h, --help     show this help message and exit
-  -v, --version  display version information
-  -vb VB         set the vertex batch size to use (default 10)
-  -eb EB         set the edge batch size to use (default 10)
-  -java_dates    use Java style "new Date()" instead of "datetime()"
+  -v, --version  Display version information
+  -vb VB         Set the vertex batch size to use (default 10)
+  -eb EB         Set the edge batch size to use (default 10)
+  -java_dates    Use Java style "new Date()" instead of "datetime()"
+  -assume_utc    If date fields do not contain timezone information, assume
+                 they are in UTC. By default local time is assumed otherwise.
+                 This option only applies if java_dates is also specified.
+  -rows ROWS     Specify the maximum number of rows to process. By default the
+                 whole file is processed
+
+
   ```

--- a/csv-gremlin/csv-gremlin.py
+++ b/csv-gremlin/csv-gremlin.py
@@ -20,7 +20,7 @@
 @deffield    created:  2020-11-17
 
 Overview
-
+--------
 This file contains the definition for a NeptuneCSVReader class. Its purpose is
 to provide a tool able to read CSV files that use the Amazon Neptune formatting
 rules and generate Gremlin steps from that data.  Those Gremlin steps can then
@@ -38,13 +38,14 @@ edges, along with their properties, to be added in a single Gremlin query.
 Gremlin steps that represent the data in the CSV are written to 'stdout'. 
 
 Current Limitations
-
+-------------------
 Currently the tool does not support the cardinality column header such as
 'age:Int(single)'. Likewise lists of values declared using the '[]' column
 header modifier are not supported.     
 
-In this initial version none of the special column headers are allowed to
-be omitted. Those being (~id, ~label, ~from, ~to).
+None of the special column headers are allowed to be omitted except for ~label in the
+case of vertices.  In that case a default label "vertex" will be used. The special
+headers are ~id, ~label, ~from and ~to.
 '''
 import csv
 import sys
@@ -53,15 +54,17 @@ import datetime
 import dateutil.parser as dparser
 
 class NeptuneCSVReader:
-    VERSION = 0.12
-    VERSION_DATE = '2020-11-19'
+    VERSION = 0.13
+    VERSION_DATE = '2020-11-20'
     INTEGERS = ('BYTE','SHORT','INT','LONG')
     FLOATS = ('FLOAT','DOUBLE')
 
-    def __init__(self, vbatch=1, ebatch=1, java_dates=False):
+    def __init__(self, vbatch=1, ebatch=1, java_dates=False, max_rows=sys.maxsize, assume_utc=False):
         self.vertex_batch_size = vbatch
         self.edge_batch_size = ebatch
         self.use_java_date = java_dates
+        self.row_limit = max_rows
+        self.assume_utc = assume_utc
 
     def get_batch_sizes(self):
         return {'vbatch': self.vertex_batch_size,
@@ -77,10 +80,37 @@ class NeptuneCSVReader:
     def get_java_dates(self):
         return self.use_java_date
 
+    def set_max_rows(self,r):
+        self.row_limit = r
+
+    def get_max_rows(self):
+        return self.row_limit
+
+    def set_assume_utc(self,utc):
+        self.assume_utc = utc
+
+    def get_assume_utc(self):
+        return self.assume_utc
+
+
+    # If use_java_date is not set, the date string from the CSV file is wrapped
+    # as-is inside a datetime(). If use_java_date is set, the ISO date string
+    # is converted into a datetime and the delta from 1970 is calculated using
+    # epoch time. As Python cannot subtract a TZ aware date and a naiive date,
+    # if no TZ offset is present in the CSV date, it is treated as being in
+    # local TZ when this code is run. However, if assume_utc is set, the date
+    # will be treated as UTC instead of local time.
+
     def process_date(self,row,key):
+        """Return an ISO 8601 date appropriately converted and wrapped"""
         if self.use_java_date:
-            epoch = datetime.datetime.utcfromtimestamp(0)
+            epoch = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
             date =  dparser.isoparse(row[key])
+            if date.tzinfo is None:
+                if self.assume_utc:
+                    date =  date.replace(tzinfo=datetime.timezone.utc)
+                else:
+                    date =  date.replace(tzinfo=datetime.datetime.now().astimezone().tzinfo)
             delta = int((date - epoch).total_seconds() * 1000)
             val = f'new Date({delta})'
         else:
@@ -89,6 +119,7 @@ class NeptuneCSVReader:
 
     def process_vertices(self,reader):
         count = 0
+        rows_processed = 0
         batch = "g"
         for row in reader:
             batch += self.process_vertex_row(row)
@@ -97,11 +128,15 @@ class NeptuneCSVReader:
                 count = 0
                 print(batch)
                 batch = 'g'
+            rows_processed += 1
+            if rows_processed == self.row_limit:
+                break
         if batch != 'g':        
             print(batch)
 
     def process_edges(self,reader):
         count = 0
+        rows_processed = 0
         batch = 'g'
         for row in reader:
             batch += self.process_edge_row(row)
@@ -110,6 +145,9 @@ class NeptuneCSVReader:
                 count = 0
                 print(batch)
                 batch = 'g'
+            rows_processed += 1
+            if rows_processed == self.row_limit:
+                break
         if batch != 'g':        
             print(batch)
 
@@ -152,6 +190,7 @@ class NeptuneCSVReader:
 
     def process_vertex_row(self,r):
         properties = ''
+        vlabel = 'vertex'
         for k in r:
             if r[k] == '':
                 pass
@@ -166,6 +205,7 @@ class NeptuneCSVReader:
         return vertex
         
     def process_csv_file(self,fname):
+        """Appropriately process the CSV file as either vertices or edges"""
         with open(fname, newline='') as csvfile:
             reader = csv.DictReader(csvfile)
             
@@ -178,18 +218,27 @@ class NeptuneCSVReader:
 if __name__ == '__main__':
     ncsv = NeptuneCSVReader()
     parser = argparse.ArgumentParser()
-    parser.add_argument('csvfile', help='the name of the CSV file to process')
+    parser.add_argument('csvfile', help='The name of the CSV file to process')
     parser.add_argument('-v','--version', action='version', 
-                        help='display version information', 
+                        help='Display version information', 
                         version=f"\ncsv-gremlin: version {ncsv.VERSION}, {ncsv.VERSION_DATE}")
     parser.add_argument('-vb', type=int, default=10,
-                        help='set the vertex batch size to use (default %(default)s)')
+                        help='Set the vertex batch size to use (default %(default)s)')
     parser.add_argument('-eb', type=int, default=10,
-                        help='set the edge batch size to use (default %(default)s)')
+                        help='Set the edge batch size to use (default %(default)s)')
     parser.add_argument('-java_dates', action='store_true',
-                        help='use Java style "new Date()" instead of "datetime()"')
+                        help='Use Java style "new Date()" instead of "datetime()"')
+    parser.add_argument('-assume_utc', action='store_true',
+                        help='If date fields do not contain timezone information, assume they are in UTC.\
+                              By default local time is assumed otherwise. This option only applies if\
+                              java_dates is also specified.')
+    parser.add_argument('-rows', type=int,
+                        help='Specify the maximum number of rows to process. By default the whole file is processed')
 
     args = parser.parse_args()
     ncsv.set_batch_sizes(vbatch=args.vb, ebatch=args.eb)
     ncsv.set_java_dates(args.java_dates)
+    if args.rows is not None:
+        ncsv.set_max_rows(args.rows)
+    ncsv.set_assume_utc(args.assume_utc)
     ncsv.process_csv_file(args.csvfile)

--- a/csv-gremlin/test.csv
+++ b/csv-gremlin/test.csv
@@ -8,3 +8,4 @@ p-6,Person,Jon,Wilson,2006-01-14,,
 p-7,Person,Jane,,2006-01-14,,
 p-8,,Frank,Jennings,2001-08-17,,
 p-9,Person,Rod,Arthurs,1965-02-01T09:01:30Z,88,1
+p-10,Person,Albert,Newyear,1999-12-31T23:59:59-0500,,

--- a/csv-gremlin/test.csv
+++ b/csv-gremlin/test.csv
@@ -6,5 +6,5 @@ p-4,Person,Nigel,Smith,2006-01-14,66.9,3
 p-5,Person,Ian,York,2006-01-14,,3
 p-6,Person,Jon,Wilson,2006-01-14,,
 p-7,Person,Jane,,2006-01-14,,
-
-
+p-8,,Frank,Jennings,2001-08-17,,
+p-9,Person,Rod,Arthurs,1965-02-01T09:01:30Z,88,1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added an option to limit the number of CSV rows that are processed.
- Added an option to specify how dates with no TZ info are processed (can assume UTC or local time) when generating Java style dates.
- Tightened up some edge cases in date processing overall to ensure dates always have a TZ. This fixes an issue when trying to compare naive and non-naive dates.
- The ~label column in vertex CSV files is now optional and a default of 'vertex' will be used.
- Updated the README.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
