### PR TITLE
Make LazyHttpHeaders iterable

### DIFF
--- a/neptune-python-utils/neptune_python_utils/endpoints.py
+++ b/neptune-python-utils/neptune_python_utils/endpoints.py
@@ -46,7 +46,9 @@ class LazyHttpHeaders:
         
     def items(self):
         return self.lazy_headers().items()
-   
+        
+    def __iter__(self):
+        return iter(self.items())   
         
 class RequestParameters:
     


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-neptune-tools/issues/134

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
