### PR TITLE
Corrected additional parameter key name

### DIFF
--- a/neptune-streams-utils/examples/java8/src/main/java/stream_handler/StreamHandler.java
+++ b/neptune-streams-utils/examples/java8/src/main/java/stream_handler/StreamHandler.java
@@ -88,7 +88,7 @@ public class StreamHandler extends AbstractStreamHandler {
 
     private Cluster createCluster() {
         Cluster.Builder builder = Cluster.build()
-                .addContactPoint(String.valueOf(additionalParams.get("neptune_endpoint")))
+                .addContactPoint(String.valueOf(additionalParams.get("neptune_cluster_endpoint")))
                 .port((int) additionalParams.get("neptune_port"))
                 .enableSsl(true)
                 .minConnectionPoolSize(1)


### PR DESCRIPTION
Additional param within Environment variable for Lambda is set as neptune_cluster_endpoint - https://github.com/awslabs/amazon-neptune-tools/blob/master/neptune-streams-utils/provisioning/provision_neptune_streams_handler.py#L156

Hence, renaming neptune_endpoint to neptune_cluster_endpoint.

*Issue #, if available:*

*Description of changes:*
Connection to neptune cluster was failing from Lambda during initialisation. Renaming additional param set as part of environment variable from neptune_endpoint to neptune_cluster_endpoint fixed the issue. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
