### PR TITLE
Update path for Neptune to ES export artifacts

### DIFF
--- a/export-neptune-to-elasticsearch/cloudformation-templates/export-neptune-to-elasticsearch.json
+++ b/export-neptune-to-elasticsearch/cloudformation-templates/export-neptune-to-elasticsearch.json
@@ -341,7 +341,7 @@
                 "neptune-stream",
                 "lambda",
                 "python36",
-		"release_2021_08_23",
+		"release_2022_01_27",
                 "neptune-streams-layer.zip"
               ]
             ]
@@ -397,7 +397,7 @@
                 "neptune-stream",
                 "lambda",
                 "python36",
-		"release_2021_08_23",
+		"release_2022_01_27",
                 "neptune-es-layer.zip"
               ]
             ]


### PR DESCRIPTION
A new version of Neptune to ES processing is released in order to support new OpenSearch versions. Need to update path of lambda artifacts to point to new versions.

*Issue #, if available:* https://github.com/awslabs/amazon-neptune-tools/issues/185

*Description of changes:* 
Made a change in underlying module used which was blocking requests to new OpenSearch versions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
