### PR TITLE
Issue 200 - Add a -double_suffix option 

### DIFF
--- a/csv-gremlin/README.md
+++ b/csv-gremlin/README.md
@@ -93,10 +93,9 @@ Rows=13, IDs=5, Duplicate IDs=7, Vertices=5, Edges=0, Properties=17, Errors=0
 
 The help can always be displayed using the `-h` or `--help` command line arguments.
 ```
-$ python csv-gremlin.py -h
-usage: csv-gremlin.py [-h] [-v] [-vb VB] [-eb EB] [-java_dates] [-assume_utc]
-                      [-rows ROWS] [-all_errors] [-silent] [-no_summary]
-                      [-escape_dollar]
+==>python3 csv-gremlin.py -h
+usage: csv-gremlin.py [-h] [-v] [-vb VB] [-eb EB] [-java_dates] [-assume_utc] [-rows ROWS] [-all_errors] [-silent]
+                      [-no_summary] [-double_suffix] [-escape_dollar]
                       csvfile
 
 positional arguments:
@@ -107,22 +106,18 @@ optional arguments:
   -v, --version   Display version information
   -vb VB          Set the vertex batch size to use (default 10)
   -eb EB          Set the edge batch size to use (default 10)
-  -java_dates     Use Java style "new Date()" instead of "datetime()". This
-                  option can also be used to force date validation.
-  -assume_utc     If date fields do not contain timezone information, assume
-                  they are in UTC. By default local time is assumed otherwise.
-                  This option only applies if java_dates is also specified.
-  -rows ROWS      Specify the maximum number of rows to process. By default
-                  the whole file is processed
-  -all_errors     Show all errors. By default processing stops after any error
-                  in the CSV is encountered.
-  -silent         Enable silent mode. Only errors are reported. No Gremlin is
-                  generated.
+  -java_dates     Use Java style "new Date()" instead of "datetime()". This option can also be used to force date
+                  validation.
+  -assume_utc     If date fields do not contain timezone information, assume they are in UTC. By default local time
+                  is assumed otherwise. This option only applies if java_dates is also specified.
+  -rows ROWS      Specify the maximum number of rows to process. By default the whole file is processed
+  -all_errors     Show all errors. By default processing stops after any error in the CSV is encountered.
+  -silent         Enable silent mode. Only errors are reported. No Gremlin is generated.
   -no_summary     Do not show a summary report after processing.
-  -escape_dollar  For any dollar signs found convert them to an escaped form
-                  \$. This is needed if you are going to load the generated
-                  Gremlin using a Groovy processor such as used by the Gremlin
-                  Console. In Groovy strings, the $ sign is used for
-                  interpolation
-
+  -double_suffix  Suffix all floats and doubles with a "d" such as 12.34d. This is helpful when using the Gremlin
+                  Console or Groovy scripts as it will prevent floats and doubles automatically being created as
+                  BigDecimal objects.
+  -escape_dollar  For any dollar signs found convert them to an escaped form \$. This is needed if you are going to
+                  load the generated Gremlin using a Groovy processor such as used by the Gremlin Console. In Groovy
+                  strings, the $ sign is used for interpolation
   ```

--- a/csv-gremlin/test-files/doubles.csv
+++ b/csv-gremlin/test-files/doubles.csv
@@ -1,0 +1,2 @@
+~id,~label,value:double,set:double[],optional
+abc-1,person,23.6,12.34;56.789,


### PR DESCRIPTION
*Issue #, if available:*
#200 
*Description of changes:*
Added a new `-double_suffix` option that will generate a type suffix for any float or double values; such as `123.456d`. This is useful when loading via the Gremlin Console or Groovy scripts, as it prevents the values from being created as BigDecimal objects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
