### PR TITLE
make MaxFileDescriptorCount configurable for neptune-export service

### DIFF
--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/CreatePropertyGraphExportConfig.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/CreatePropertyGraphExportConfig.java
@@ -103,7 +103,8 @@ public class CreatePropertyGraphExportConfig extends NeptuneExportCommand implem
                                     new PropertyGraphRangeModule().config(),
                                     gremlinFilters.filters(),
                                     cluster.concurrencyConfig(),
-                                    targetConfig, featureToggles());
+                                    targetConfig, featureToggles(),
+                                    getMaxFileDescriptorCount());
 
                             graphSchema = exportJob.execute();
 

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraph.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraph.java
@@ -121,7 +121,8 @@ public class ExportPropertyGraph extends NeptuneExportCommand implements Runnabl
                                 gremlinFilters.filters(),
                                 cluster.concurrencyConfig(),
                                 targetConfig,
-                                featureToggles());
+                                featureToggles(),
+                                getMaxFileDescriptorCount());
 
                         graphSchema = Timer.timedActivity(
                                 "export",

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraphFromConfig.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraphFromConfig.java
@@ -102,7 +102,8 @@ public class ExportPropertyGraphFromConfig extends NeptuneExportCommand implemen
                                 range.config(),
                                 gremlinFilters.filters(),
                                 cluster.concurrencyConfig(),
-                                targetConfig, featureToggles());
+                                targetConfig, featureToggles(),
+                                getMaxFileDescriptorCount());
 
                         graphSchema = exportJob.execute();
 

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/NeptuneExportCommand.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/NeptuneExportCommand.java
@@ -38,6 +38,8 @@ public abstract class NeptuneExportCommand extends NeptuneExportBaseCommand impl
 
     private boolean isCliInvocation = false;
 
+    private int maxFileDescriptorCount;
+
     private NeptuneExportEventHandler eventHandler = NeptuneExportEventHandler.NULL_EVENT_HANDLER;
 
     @Override
@@ -82,5 +84,13 @@ public abstract class NeptuneExportCommand extends NeptuneExportBaseCommand impl
 
     FeatureToggles featureToggles() {
         return featureToggleModule.featureToggles();
+    }
+
+    public int getMaxFileDescriptorCount() {
+        return maxFileDescriptorCount;
+    }
+
+    public void setMaxFileDescriptorCount(int maxFileDescriptorCount) {
+        this.maxFileDescriptorCount = maxFileDescriptorCount;
     }
 }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/RunNeptuneExportSvc.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/RunNeptuneExportSvc.java
@@ -30,6 +30,11 @@ import java.nio.charset.StandardCharsets;
 @Command(name = "nesvc", description = "neptune-export service", hidden = true)
 public class RunNeptuneExportSvc extends NeptuneExportBaseCommand implements Runnable {
 
+    /**
+     * Same as the default value given in the CFN template at https://docs.aws.amazon.com/neptune/latest/userguide/export-service.html
+     */
+    public static final int DEFAULT_MAX_FILE_DESCRIPTOR_COUNT = 10000;
+
     @Option(name = {"--json"}, description = "JSON")
     @Once
     private String json;
@@ -42,13 +47,17 @@ public class RunNeptuneExportSvc extends NeptuneExportBaseCommand implements Run
     @Once
     private boolean cleanRootPath = false;
 
+    @Option(name = {"--max-file-descriptor-count"}, description = "Maximum number of simultaneously open files.", hidden = true)
+    @Once
+    private int maxFileDescriptorCount = DEFAULT_MAX_FILE_DESCRIPTOR_COUNT;
+
     @Override
     public void run() {
 
         InputStream input = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
 
         try {
-            new NeptuneExportLambda(rootPath, cleanRootPath).handleRequest(input, System.out, new Context() {
+            new NeptuneExportLambda(rootPath, cleanRootPath, maxFileDescriptorCount).handleRequest(input, System.out, new Context() {
                 @Override
                 public String getAwsRequestId() {
                     throw new NotImplementedException();

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
@@ -336,7 +336,7 @@ public class ExportToS3NeptuneExportEventHandler implements NeptuneExportEventHa
 
                 ObjectTaggingProvider taggingProvider = uploadContext -> createObjectTags(profiles);
 
-                logger.info("Uploading export files to {}", outputS3ObjectInfo.key());
+                logger.info("Uploading export files to s3 bucket={} key={}", outputS3ObjectInfo.bucket(), outputS3ObjectInfo.key());
 
                 MultipleFileUpload upload = transferManager.uploadDirectory(
                         outputS3ObjectInfo.bucket(),

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/export/NeptuneExportLambda.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/export/NeptuneExportLambda.java
@@ -12,6 +12,16 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.export;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.amazonaws.services.neptune.util.EnvironmentVariableUtils;
@@ -19,12 +29,8 @@ import com.amazonaws.services.neptune.util.S3ObjectInfo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-
+import static com.amazonaws.services.neptune.RunNeptuneExportSvc.DEFAULT_MAX_FILE_DESCRIPTOR_COUNT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class NeptuneExportLambda implements RequestStreamHandler {
@@ -33,14 +39,16 @@ public class NeptuneExportLambda implements RequestStreamHandler {
 
     private final String localOutputPath;
     private final boolean cleanOutputPath;
+    private final int maxFileDescriptorCount;
 
     public NeptuneExportLambda() {
-        this(TEMP_PATH, true);
+        this(TEMP_PATH, true, DEFAULT_MAX_FILE_DESCRIPTOR_COUNT);
     }
 
-    public NeptuneExportLambda(String localOutputPath, boolean cleanOutputPath) {
+    public NeptuneExportLambda(String localOutputPath, boolean cleanOutputPath, int maxFileDescriptorCount) {
         this.localOutputPath = localOutputPath;
         this.cleanOutputPath = cleanOutputPath;
+        this.maxFileDescriptorCount = maxFileDescriptorCount;
     }
 
     @Override
@@ -145,7 +153,8 @@ public class NeptuneExportLambda implements RequestStreamHandler {
                 completionFilePayload,
                 additionalParams,
                 maxConcurrency,
-                s3Region);
+                s3Region,
+                maxFileDescriptorCount);
 
         S3ObjectInfo outputS3ObjectInfo = neptuneExportService.execute();
 

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/export/NeptuneExportRunner.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/export/NeptuneExportRunner.java
@@ -17,20 +17,25 @@ import com.amazonaws.services.neptune.NeptuneExportCommand;
 import com.amazonaws.services.neptune.NeptuneExportEventHandlerHost;
 import org.apache.commons.lang.StringUtils;
 
+import static com.amazonaws.services.neptune.export.NeptuneExportService.MAX_FILE_DESCRIPTOR_COUNT;
+
 public class NeptuneExportRunner {
 
     private final String[] args;
     private final NeptuneExportEventHandler eventHandler;
     private final boolean isCliInvocation;
+    private final int maxFileDescriptorCount;
 
     public NeptuneExportRunner(String[] args) {
-        this(args, NeptuneExportEventHandler.NULL_EVENT_HANDLER, true);
+        this(args, NeptuneExportEventHandler.NULL_EVENT_HANDLER, true, MAX_FILE_DESCRIPTOR_COUNT);
     }
 
-    public NeptuneExportRunner(String[] args, NeptuneExportEventHandler eventHandler, boolean isCliInvocation) {
+    public NeptuneExportRunner(String[] args, NeptuneExportEventHandler eventHandler,
+                               boolean isCliInvocation, int maxFileDescriptorCount) {
         this.args = args;
         this.eventHandler = eventHandler;
         this.isCliInvocation = isCliInvocation;
+        this.maxFileDescriptorCount = maxFileDescriptorCount;
     }
 
     public void run() {
@@ -55,6 +60,10 @@ public class NeptuneExportRunner {
 
             if (NeptuneExportCommand.class.isAssignableFrom(cmd.getClass())){
                 ((NeptuneExportCommand) cmd).setIsCliInvocation(isCliInvocation);
+            }
+
+            if (NeptuneExportCommand.class.isAssignableFrom(cmd.getClass())){
+                ((NeptuneExportCommand) cmd).setMaxFileDescriptorCount(maxFileDescriptorCount);
             }
 
             cmd.run();

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/ExportPropertyGraphJob.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/ExportPropertyGraphJob.java
@@ -48,6 +48,7 @@ public class ExportPropertyGraphJob {
     private final ConcurrencyConfig concurrencyConfig;
     private final PropertyGraphTargetConfig targetConfig;
     private final FeatureToggles featureToggles;
+    private final int maxFileDescriptorCount;
 
     public ExportPropertyGraphJob(Collection<ExportSpecification> exportSpecifications,
                                   GraphSchema graphSchema,
@@ -56,7 +57,8 @@ public class ExportPropertyGraphJob {
                                   GremlinFilters gremlinFilters,
                                   ConcurrencyConfig concurrencyConfig,
                                   PropertyGraphTargetConfig targetConfig,
-                                  FeatureToggles featureToggles) {
+                                  FeatureToggles featureToggles,
+                                  int maxFileDescriptorCount) {
         this.exportSpecifications = exportSpecifications;
         this.graphSchema = graphSchema;
         this.g = g;
@@ -65,6 +67,7 @@ public class ExportPropertyGraphJob {
         this.concurrencyConfig = concurrencyConfig;
         this.targetConfig = targetConfig;
         this.featureToggles = featureToggles;
+        this.maxFileDescriptorCount = maxFileDescriptorCount;
     }
 
     public GraphSchema execute() throws Exception {
@@ -115,7 +118,8 @@ public class ExportPropertyGraphJob {
                             rangeFactory,
                             status,
                             fileIndex,
-                            fileDescriptorCount
+                            fileDescriptorCount,
+                            maxFileDescriptorCount
                     );
                     futures.add(taskExecutor.submit(exportTask));
                 }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/ExportPropertyGraphTask.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/ExportPropertyGraphTask.java
@@ -50,7 +50,8 @@ public class ExportPropertyGraphTask<T extends Map<?, ?>> implements Callable<Fi
                                    GremlinFilters gremlinFilters,
                                    Status status,
                                    AtomicInteger index,
-                                   AtomicInteger fileDescriptorCount) {
+                                   AtomicInteger fileDescriptorCount,
+                                   int maxFileDescriptorCount) {
         this.graphElementSchemas = graphElementSchemas;
         this.labelsFilter = labelsFilter;
         this.graphClient = graphClient;
@@ -60,7 +61,7 @@ public class ExportPropertyGraphTask<T extends Map<?, ?>> implements Callable<Fi
         this.gremlinFilters = gremlinFilters;
         this.status = status;
         this.index = index;
-        this.labelWriters = new LabelWriters<>(fileDescriptorCount);
+        this.labelWriters = new LabelWriters<>(fileDescriptorCount, maxFileDescriptorCount);
     }
 
     @Override

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/LabelWriters.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/LabelWriters.java
@@ -24,13 +24,14 @@ public class LabelWriters<T extends Map<?, ?>> implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(LabelWriters.class);
 
-    private static final int MAX_FILE_DESCRIPTOR_COUNT = 9000;
+    private final int maxFileDescriptorCount;
 
     private final AtomicInteger fileDescriptorCount;
     private final LinkedHashMap<Label, LabelWriter<T>> labelWriters = new LinkedHashMap<>(16, 0.75f, true);
 
-    public LabelWriters(AtomicInteger fileDescriptorCount) {
+    public LabelWriters(AtomicInteger fileDescriptorCount, int maxFileDescriptorCount) {
         this.fileDescriptorCount = fileDescriptorCount;
+        this.maxFileDescriptorCount = maxFileDescriptorCount;
     }
 
     public boolean containsKey(Label label){
@@ -39,7 +40,7 @@ public class LabelWriters<T extends Map<?, ?>> implements AutoCloseable {
 
     public void put(Label label, LabelWriter<T> labelWriter) throws Exception {
 
-        if (fileDescriptorCount.get() > MAX_FILE_DESCRIPTOR_COUNT && labelWriters.size() > 1){
+        if (fileDescriptorCount.get() > maxFileDescriptorCount && labelWriters.size() > 1){
             Label leastRecentlyAccessedLabel = labelWriters.keySet().iterator().next();
             LabelWriter<T> leastRecentlyAccessedLabelWriter = labelWriters.remove(leastRecentlyAccessedLabel);
             logger.info("Closing writer for label {} for output {} so as to conserve file descriptors", leastRecentlyAccessedLabel.labelsAsString(), leastRecentlyAccessedLabelWriter.outputId());

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/ExportSpecification.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/ExportSpecification.java
@@ -102,7 +102,8 @@ public class ExportSpecification {
                                                                          RangeFactory rangeFactory,
                                                                          Status status,
                                                                          AtomicInteger index,
-                                                                         AtomicInteger fileDescriptorCount) {
+                                                                         AtomicInteger fileDescriptorCount,
+                                                                         int maxFileDescriptorCount) {
         return new ExportPropertyGraphTask<>(
                 graphSchema.copyOfGraphElementSchemasFor(graphElementType),
                 labelsFilter,
@@ -113,7 +114,8 @@ public class ExportSpecification {
                 gremlinFilters,
                 status,
                 index,
-                fileDescriptorCount
+                fileDescriptorCount,
+                maxFileDescriptorCount
         );
     }
 


### PR DESCRIPTION
*Issue #, if available:* N/A
An AWS customer reported an issue with the default value of 9000 being used for MaxFileDescriptorCount causing failure in exporting their graph containing a large number of unique labels and edges. 
[For AWS employees, see CR-68158508 for more context]

*Description of changes:*
Instead of a static value for MaxFileDescriptorCount ([code pointer](https://github.com/awslabs/amazon-neptune-tools/blob/b93899ffb0b05a528f968f92467b06c597b046e4/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/LabelWriters.java#L27)), currently 9000, pass the value from neptune-export service and use that as the MaxFileDescriptorCount after removing buffer, thus making the value configurable for customers via CFN template available at https://docs.aws.amazon.com/neptune/latest/userguide/export-service.html.

Note that there is no change to the command line tool which is set to the existing static value of 9000.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
