### PR TITLE
Fix drop-graph.py for gremlin_python 3.6.0

### DIFF
--- a/drop-graph/drop-graph.py
+++ b/drop-graph/drop-graph.py
@@ -187,7 +187,7 @@ def edge_fetcher(q,start_offset,bracket_size):
         while not success:
             print(nm,"[edges] retrieving range ({},{} batch=size={})".format(p1,p2,p2-p1))
             try:
-                edges = g.E().range(p1,p2).id().toList()
+                edges = g.E().range_(p1,p2).id_().toList()
                 success = True
             except:
                 print("***",nm,"Exception while fetching. Retrying.")
@@ -231,7 +231,7 @@ def vertex_fetcher(q,start_offset,bracket_size):
         while not success:
             print(nm,"[vertices] retrieving range ({},{} batch=size={})".format(p1,p2,p2-p1))
             try:
-                vertices = g.V().range(p1,p2).id().toList()
+                vertices = g.V().range_(p1,p2).id_().toList()
                 success = True
             except:
                 print("***",nm,"Exception while fetching. Retrying.")


### PR DESCRIPTION
The use of:

    edges = g.E().range(p1,p2).id().toList()
    vertices = g.V().range(p1,p2).id().toList()

does not work work anymore in Python 3 and gremlin_python 3.6.0:

    Exception in thread Thread-1:
    Traceback (most recent call last):
      File "/home/ec2-user/drop.py", line 190, in edge_fetcher
        edges = g.E().range(p1,p2).id().toList()
    TypeError: 'GraphTraversal' object is not callable

Fix is to use:

    edges = g.E().range_(p1,p2).id_().toList()
    vertices = g.V().range_(p1,p2).id_().toList()

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
