### PR TITLE
Bump to TinkerPop 3.5.2

### DIFF
--- a/neptune-gremlin-client/gremlin-client-demo/pom.xml
+++ b/neptune-gremlin-client/gremlin-client-demo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>neptune-gremlin-client</artifactId>
         <groupId>software.amazon.neptune</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/neptune-gremlin-client/gremlin-client-demo/src/main/java/software/amazon/neptune/RefreshAgentDemo.java
+++ b/neptune-gremlin-client/gremlin-client-demo/src/main/java/software/amazon/neptune/RefreshAgentDemo.java
@@ -12,7 +12,7 @@ permissions and limitations under the License.
 
 package software.amazon.neptune;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tinkerpop.gremlin.driver.IamAuthConfig;
 import software.amazon.neptune.cluster.*;
 import com.github.rvesse.airline.annotations.Command;

--- a/neptune-gremlin-client/gremlin-client-demo/src/main/java/software/amazon/neptune/RollingSubsetOfEndpointDemo.java
+++ b/neptune-gremlin-client/gremlin-client-demo/src/main/java/software/amazon/neptune/RollingSubsetOfEndpointDemo.java
@@ -12,7 +12,7 @@ permissions and limitations under the License.
 
 package software.amazon.neptune;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tinkerpop.gremlin.driver.IamAuthConfig;
 import software.amazon.neptune.cluster.EndpointsSelector;
 import software.amazon.neptune.cluster.NeptuneGremlinClusterBuilder;

--- a/neptune-gremlin-client/gremlin-client/pom.xml
+++ b/neptune-gremlin-client/gremlin-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>neptune-gremlin-client</artifactId>
         <groupId>software.amazon.neptune</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/neptune-gremlin-client/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/GremlinClusterBuilder.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/GremlinClusterBuilder.java
@@ -44,7 +44,7 @@ public class GremlinClusterBuilder {
     private int maxInProcessPerConnection = Connection.MAX_IN_PROCESS;
     private int minInProcessPerConnection = Connection.MIN_IN_PROCESS;
     private int maxWaitForConnection = Connection.MAX_WAIT_FOR_CONNECTION;
-    private int maxWaitForSessionClose = Connection.MAX_WAIT_FOR_SESSION_CLOSE;
+    private int maxWaitForClose = Connection.MAX_WAIT_FOR_CLOSE;
     private int maxContentLength = Connection.MAX_CONTENT_LENGTH;
     private int reconnectInterval = Connection.RECONNECT_INTERVAL;
     private int resultIterationBatchSize = Connection.RESULT_ITERATION_BATCH_SIZE;
@@ -373,9 +373,8 @@ public class GremlinClusterBuilder {
      * for that session to close before timing out where the default value is 3000. Note that the server will
      * eventually clean up dead sessions itself on expiration of the session or during shutdown.
      */
-    @Deprecated
-    public GremlinClusterBuilder maxWaitForSessionClose(final int maxWait) {
-        this.maxWaitForSessionClose = maxWait;
+    public GremlinClusterBuilder maxWaitForClose(final int maxWait) {
+        this.maxWaitForClose = maxWait;
         return this;
     }
 
@@ -530,7 +529,7 @@ public class GremlinClusterBuilder {
                     .validationRequest(validationRequest)
                     .channelizer(channelizer)
                     .maxContentLength(maxContentLength)
-                    .maxWaitForSessionClose(maxWaitForSessionClose)
+                    .maxWaitForClose(maxWaitForClose)
                     .resultIterationBatchSize(resultIterationBatchSize)
                     .minConnectionPoolSize(minConnectionPoolSize)
                     .maxConnectionPoolSize(maxConnectionPoolSize)

--- a/neptune-gremlin-client/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/LBAwareHandshakeInterceptor.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/LBAwareHandshakeInterceptor.java
@@ -20,7 +20,7 @@ package org.apache.tinkerpop.gremlin.driver;
 import com.amazonaws.neptune.auth.NeptuneNettyHttpSigV4Signer;
 import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
 import io.netty.handler.codec.http.FullHttpRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.utils.RegionUtils;

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/GetEndpointsFromLambdaProxy.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/GetEndpointsFromLambdaProxy.java
@@ -25,7 +25,7 @@ import com.evanlennick.retry4j.CallExecutorBuilder;
 import com.evanlennick.retry4j.Status;
 import com.evanlennick.retry4j.config.RetryConfig;
 import com.evanlennick.retry4j.config.RetryConfigBuilder;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tinkerpop.gremlin.driver.IamAuthConfig;
 import software.amazon.utils.RegionUtils;
 

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/GetEndpointsFromNeptuneManagementApi.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/GetEndpointsFromNeptuneManagementApi.java
@@ -17,7 +17,7 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.neptune.AmazonNeptune;
 import com.amazonaws.services.neptune.AmazonNeptuneClientBuilder;
 import com.amazonaws.services.neptune.model.*;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tinkerpop.gremlin.driver.IamAuthConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneGremlinClusterBuilder.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneGremlinClusterBuilder.java
@@ -184,9 +184,8 @@ public class NeptuneGremlinClusterBuilder {
         return this;
     }
 
-    @Deprecated
-    public NeptuneGremlinClusterBuilder maxWaitForSessionClose(final int maxWait) {
-        innerBuilder.maxWaitForSessionClose(maxWait);
+    public NeptuneGremlinClusterBuilder maxWaitForClose(final int maxWait) {
+        innerBuilder.maxWaitForClose(maxWait);
         return this;
     }
 

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/utils/RegionUtils.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/utils/RegionUtils.java
@@ -14,7 +14,7 @@ package software.amazon.utils;
 
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class RegionUtils {
     public static String getCurrentRegionName(){

--- a/neptune-gremlin-client/neptune-endpoints-info-lambda/pom.xml
+++ b/neptune-gremlin-client/neptune-endpoints-info-lambda/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>neptune-gremlin-client</artifactId>
         <groupId>software.amazon.neptune</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/neptune-gremlin-client/pom.xml
+++ b/neptune-gremlin-client/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <javac.target>1.8</javac.target>
         <aws.sdk.version>1.12.38</aws.sdk.version>
-        <gremlin.driver.version>3.4.13</gremlin.driver.version>
+        <gremlin.driver.version>3.5.2</gremlin.driver.version>
         <jackson.databind.version>2.13.2.2</jackson.databind.version>
         <jackson.dataformat.version>2.13.2</jackson.dataformat.version>
         <sigv4.version>2.4.0</sigv4.version>

--- a/neptune-gremlin-client/pom.xml
+++ b/neptune-gremlin-client/pom.xml
@@ -7,7 +7,7 @@
     <groupId>software.amazon.neptune</groupId>
     <artifactId>neptune-gremlin-client</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/neptune-gremlin-client/readme.md
+++ b/neptune-gremlin-client/readme.md
@@ -4,6 +4,10 @@ A Java Gremlin client for Amazon Neptune that allows you to change the endpoints
 
 The client also provides support for IAM database authentication, and for connecting to Neptune via a network or application load balancer.
 
+  - **[New May 10 2022 – version 1.0.4]** Upgraded to version 3.5.2 of the Java Gremlin driver.
+  
+  - **[New May 5 2022 – version 1.0.3]** Upgraded to version 3.4.13 of the Java Gremlin driver.
+
   - **[New January 2022 – version 1.0.2]** `GremlinClient.chooseConnection()` now respects the connection pool's `maxWaitForConnection` timeout value. Improves the way in which consecutive failures to acquire a connection can trigger endpoint refresh behaviours.
 
   - **[New July 2021]** Upgraded to version 3.4.12 of the Java Gremlin driver.


### PR DESCRIPTION
version upgrade to TinkerPop 3.5.2 for gremlin-client 1.0.4.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
