### PR TITLE
Prevent duplication of gremlin filters

### DIFF
--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinFilters.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinFilters.java
@@ -16,7 +16,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.tinkerpop.gremlin.jsr223.CachedGremlinScriptEngineManager;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
-import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Element;
@@ -76,15 +75,10 @@ public class GremlinFilters {
         } catch (ScriptException e) {
             throw new IllegalStateException(String.format("Invalid Gremlin filter: %s. %s", gremlin, e.getMessage()), e);
         }
-
-        for (Step<?, ?> step : whereTraversal.getSteps()) {
-
-            for (Bytecode.Instruction instruction : step.getTraversal().getBytecode().getInstructions()) {
-                String operator = instruction.getOperator();
-                validateOperator(operator);
-                t.asAdmin().getBytecode().addStep(operator, instruction.getArguments());
-            }
-            t.asAdmin().addStep(step);
+        for (Bytecode.Instruction instruction : whereTraversal.getBytecode().getInstructions()) {
+            String operator = instruction.getOperator();
+            validateOperator(operator);
+            t.asAdmin().getBytecode().addStep(operator, instruction.getArguments());
         }
 
         return t;


### PR DESCRIPTION
Issue #219 

When iterating through the gremlin filter steps, the call to `getTraversal()` would get the parent traversal.  This is problematic when there are multiple steps since, each step, will get the parent and then build the traversal from the root.  The end result is that the entire traversal will be repeated _n_ times, where _n_ is the number of steps in the query filter passed in.

Quick examples:

#### Only one step:
##### Query
`hasLabel('Pet')`

##### Output
```
__.V()
.hasLabel("Pet")
```

#### Multiple steps
##### Query
`hasLabel('Pet').or(hasLabel('Dog'), hasLabel('Cat'))`

##### Output
```
__.V()
.hasLabel("Pet").or(__.hasLabel("Dog"),__.hasLabel("Cat"))
.hasLabel("Pet").or(__.hasLabel("Dog"),__.hasLabel("Cat))
```


From the queries I have been working with it appears that simply using the `whereTraversal` was sufficient to build out the graph traversal.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
