### PR TITLE
fix possibility of integer overflow in Status logs of neptune-export

### DIFF
--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/io/Status.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/io/Status.java
@@ -12,18 +12,18 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.io;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 
 public class Status {
 
     private static final Logger logger = LoggerFactory.getLogger(Status.class);
 
-    private final AtomicInteger counter = new AtomicInteger();
+    private final AtomicLong counter = new AtomicLong();
     private final AtomicBoolean allowContinue = new AtomicBoolean(true);
     private final StatusOutputFormat outputFormat;
     private final String description;
@@ -44,7 +44,7 @@ public class Status {
     }
 
     public void update() {
-        int counterValue = counter.incrementAndGet();
+        long counterValue = counter.incrementAndGet();
         if (counterValue % 10000 == 0 && outputFormat == StatusOutputFormat.Dot) {
             System.err.print(".");
         } else if (counterValue % 100000 == 0 && outputFormat == StatusOutputFormat.Description) {


### PR DESCRIPTION
*Issue #, if available:* N/A
An AWS customer reported that they were seeing negative values in their export job's CloudWatch logs for an export of data having total edges greater than `Integer.MAX_VALUE`.
The `numberOfItemsToExport` has the data type `long` at [RangeFactory.java#L64](https://github.com/awslabs/amazon-neptune-tools/blob/master/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/RangeFactory.java#L64) but the Status class was using `AtomicInteger`/`int` for the log statement at [Status.java#L51](https://github.com/awslabs/amazon-neptune-tools/blob/master/neptune-export/src/main/java/com/amazonaws/services/neptune/io/Status.java#L51).
[For AWS employees, see CR-70441879 for more context]

*Description of changes:*
Change the data type of `counter` being logged in Status class from `AtomicInteger`/`int` to `AtomicLong`/`long`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
