### PR TITLE
Update Lambda dependencies for Neptune-ES export tool

### DIFF
--- a/export-neptune-to-elasticsearch/lambda/requirements.txt
+++ b/export-neptune-to-elasticsearch/lambda/requirements.txt
@@ -1,7 +1,7 @@
 protobuf==3.15.0
-six==1.11.0
+six==1.16.0
 elasticsearch==6.4.0
-rdflib
+rdflib==6.1.1
 retrying
 requests
 requests_aws4auth


### PR DESCRIPTION
*Issue #, if available:* #224

*Description of changes:*
- Updated Lambda artifact dependencies for the `export-neptune-to-elasticsearch` tool. This brings the dependency versions in line with the upgrades to the Lambda layer for Python 3.9 (#223).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
