### PR TITLE
[export-neptune-to-elasticsearch] [Issue 226] Changed aws-kinesis-agg dependency to version 1.1.7. 

### DIFF
--- a/export-neptune-to-elasticsearch/lambda/README.md
+++ b/export-neptune-to-elasticsearch/lambda/README.md
@@ -1,0 +1,26 @@
+# Export Neptune to Elasticsearch Lambda Functions
+
+This stack deploys two lambda functions:
+- export-neptune-to-kinesis-\<stackId\>
+- kinesis-to-elasticsearch-\<stackId\>
+
+Both lambda functions leverage the same lambda code package, yet use different handler configurations.  The following instructions detail how to build the unified code package for both of these lambda functions.  This uses an included `build.sh` script to create a target ZIP file that can be directly pushed to AWS Lambda.
+
+NOTE:  Each lambda function also has dependencies on other Lambda Layers.  The Lambda Layers are not part of this code repository and are deployed as part of the base [Neptune Streams Poller stack](https://docs.aws.amazon.com/neptune/latest/userguide/full-text-search-cfn-create.html).
+
+## Build
+
+The entire package can be built using the following:
+
+`sh build.sh`
+
+This will create a new `target` directory with the ZIP file package used in both lambda functions.
+
+To update either lambda function, you can use:
+
+`aws lambda update-function-code --function-name export-neptune-to-kinesis-<stackId> --zip-file fileb://./target/export-neptune-to-elasticsearch.zip`
+
+or
+
+`aws lambda update-function-code --function-name kinesis-to-elasticsearch-<stackId> --zip-file fileb://./target/export-neptune-to-elasticsearch.zip`
+

--- a/export-neptune-to-elasticsearch/lambda/build.sh
+++ b/export-neptune-to-elasticsearch/lambda/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+pip install virtualenv
+rm -rf target
+rm -rf temp
+mkdir target
+virtualenv temp --python=python3.8
+source temp/bin/activate
+pip install -r requirements.txt
+cd temp/lib/python3.8/site-packages
+cp -r ../../../../*.py .
+zip -r ../../../../target/export-neptune-to-elasticsearch.zip ./*
+deactivate
+cd ../../../../
+rm -rf temp

--- a/export-neptune-to-elasticsearch/lambda/requirements.txt
+++ b/export-neptune-to-elasticsearch/lambda/requirements.txt
@@ -7,4 +7,4 @@ requests
 requests_aws4auth
 cachetools
 certifi
-aws-kinesis-agg
+aws-kinesis-agg==1.1.7


### PR DESCRIPTION
Issue #, if available:  Issue #226

Description of changes:  
Changed aws-kinesis-agg dependency to version 1.1.7. 
Added build script and README.md with build instructions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
