### PR TITLE
Update example for self-supplied credentials

### DIFF
--- a/neptune-python-utils/readme.md
+++ b/neptune-python-utils/readme.md
@@ -61,13 +61,13 @@ To supply your own credentials:
 
 ```
 from neptune_python_utils.endpoints import Endpoints
-from botocore.credentials import ReadOnlyCredentials
+from botocore.credentials import Credentials
 
 access_key = '...'
 secret_key = '...'
 token = '...'
 
-credentials = ReadOnlyCredentials(access_key, secret_key, token)
+credentials = Credentials(access_key, secret_key, token)
 
 endpoints = Endpoints(credentials=credentials)
 ```


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Updating README self-supplied credentials example to encourage use of the Credentials object rather than ReadOnlyCredentials. Using ReadOnlyCredentials will throw an Exception on line 110 in endpoints.py, as it has no get_frozen_credentials() method 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
