### PR TITLE
Fix issue parsing last commit num for engines < 1.0.4.2

### DIFF
--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/GetLastEventId.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/GetLastEventId.java
@@ -16,10 +16,32 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.function.ToIntFunction;
+import java.util.stream.Collectors;
 
 public class GetLastEventId {
+
+    public static final String MaxCommitNumValueForEngine(String engineVersion){
+        List<Integer> parts = Arrays.stream(engineVersion.split("\\."))
+                .mapToInt(Integer::valueOf)
+                .boxed()
+                .collect(Collectors.toList());
+
+
+
+        if (parts.get(1) == 0){
+            if (parts.get(2) < 4){
+                return String.valueOf(Integer.MAX_VALUE);
+            } else if (parts.get(2) == 4 && parts.get(3) < 2){
+                return String.valueOf(Integer.MAX_VALUE);
+            } else {
+                return String.valueOf(Long.MAX_VALUE);
+            }
+        } else {
+            return String.valueOf(Long.MAX_VALUE);
+        }
+    }
 
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(GetLastEventId.class);
 
@@ -75,6 +97,4 @@ public class GetLastEventId {
             return null;
         }
     }
-
-
 }

--- a/neptune-export/src/test/java/com/amazonaws/services/neptune/cluster/GetLastEventIdTest.java
+++ b/neptune-export/src/test/java/com/amazonaws/services/neptune/cluster/GetLastEventIdTest.java
@@ -1,0 +1,58 @@
+package com.amazonaws.services.neptune.cluster;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GetLastEventIdTest {
+
+    @Test
+    public void shouldReturnIntegerMaxValueForEngineVersions1041AndBelow(){
+
+        String expectedValue = String.valueOf(Integer.MAX_VALUE);
+
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.1.0"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.1.1"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.1.2"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.2.0"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.2.1"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.2.2"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.3.0"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.4.0"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.4.1"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.4.2"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.5.0"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.5.1"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.1.0.0"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.1.1.0"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.2.0.0"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.2.0.1"));
+
+    }
+
+    @Test
+    public void shouldReturnLongMaxValueForEngineVersions1041AndBelow(){
+
+        String expectedValue = String.valueOf(Long.MAX_VALUE);
+
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.1.0"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.1.1"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.1.2"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.2.0"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.2.1"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.2.2"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.3.0"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.4.0"));
+        Assert.assertNotEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.4.1"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.4.2"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.5.0"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.0.5.1"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.1.0.0"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.1.1.0"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.2.0.0"));
+        Assert.assertEquals(expectedValue, GetLastEventId.MaxCommitNumValueForEngine("1.2.0.1"));
+
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

neptune-export will infer the last commit num for cloned clusters where Neptune Streams is enabled. This fix allows the tool to infer the last commit num for Neptune engines older than 1.0.4.2.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
