### PR TITLE
Refresh agent for Lambda proxy now allows custom endpoint selectors

### DIFF
--- a/neptune-gremlin-client/gremlin-client-demo/pom.xml
+++ b/neptune-gremlin-client/gremlin-client-demo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>neptune-gremlin-client</artifactId>
         <groupId>software.amazon.neptune</groupId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/neptune-gremlin-client/gremlin-client-demo/src/main/java/software/amazon/lambda/NeptuneGremlinClientExampleLambda.java
+++ b/neptune-gremlin-client/gremlin-client-demo/src/main/java/software/amazon/lambda/NeptuneGremlinClientExampleLambda.java
@@ -27,12 +27,12 @@ import org.apache.tinkerpop.gremlin.process.remote.RemoteConnectionException;
 import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.T;
-import software.amazon.neptune.cluster.ClusterEndpointsRefreshAgent;
-import software.amazon.neptune.cluster.EndpointsType;
-import software.amazon.neptune.cluster.NeptuneGremlinClusterBuilder;
+import software.amazon.neptune.cluster.*;
 
 import java.io.*;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -72,7 +72,7 @@ public class NeptuneGremlinClientExampleLambda implements RequestStreamHandler {
         this.client = cluster.connect();
 
         refreshAgent.startPollingNeptuneAPI(
-                addresses -> client.refreshEndpoints(addresses.get(ENDPOINT_TYPE)),
+                (OnNewAddresses) addresses -> client.refreshEndpoints(addresses.get(ENDPOINT_TYPE)),
                 5,
                 TimeUnit.SECONDS);
 
@@ -132,7 +132,7 @@ public class NeptuneGremlinClientExampleLambda implements RequestStreamHandler {
 
             Class<? extends Exception> exceptionClass = e.getClass();
 
-            if (RemoteConnectionException.class.isAssignableFrom(exceptionClass)){
+            if (RemoteConnectionException.class.isAssignableFrom(exceptionClass)) {
                 System.out.println("Retrying because RemoteConnectionException");
                 return true;
             }

--- a/neptune-gremlin-client/gremlin-client-demo/src/main/java/software/amazon/neptune/RefreshAgentDemo.java
+++ b/neptune-gremlin-client/gremlin-client-demo/src/main/java/software/amazon/neptune/RefreshAgentDemo.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.utils.RegionUtils;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +112,7 @@ public class RefreshAgentDemo implements Runnable {
             GremlinClient client = cluster.connect();
 
             refreshAgent.startPollingNeptuneAPI(
-                    addresses -> client.refreshEndpoints(addresses.get(endpointsSelector)),
+                    (OnNewAddresses) addresses -> client.refreshEndpoints(addresses.get(endpointsSelector)),
                     intervalSeconds,
                     TimeUnit.SECONDS);
 

--- a/neptune-gremlin-client/gremlin-client-demo/src/main/java/software/amazon/neptune/RollingSubsetOfEndpointDemo.java
+++ b/neptune-gremlin-client/gremlin-client-demo/src/main/java/software/amazon/neptune/RollingSubsetOfEndpointDemo.java
@@ -29,7 +29,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.neptune.cluster.NeptuneInstanceProperties;
 
 import java.util.*;
 import java.util.concurrent.Executors;

--- a/neptune-gremlin-client/gremlin-client/pom.xml
+++ b/neptune-gremlin-client/gremlin-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>neptune-gremlin-client</artifactId>
         <groupId>software.amazon.neptune</groupId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterMetadataFetchStrategy.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterMetadataFetchStrategy.java
@@ -1,0 +1,5 @@
+package software.amazon.neptune.cluster;
+
+public interface ClusterMetadataFetchStrategy {
+    NeptuneClusterMetadata getClusterMetadata();
+}

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/EndpointsSelector.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/EndpointsSelector.java
@@ -17,5 +17,5 @@ import java.util.Collection;
 public interface EndpointsSelector {
     Collection<String> getEndpoints(String clusterEndpoint,
                                     String readerEndpoint,
-                                    Collection<NeptuneInstanceProperties> instances);
+                                    Collection<NeptuneInstanceMetadata> instances);
 }

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/EndpointsType.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/EndpointsType.java
@@ -26,10 +26,10 @@ public enum EndpointsType implements EndpointsSelector {
         @Override
         public Collection<String> getEndpoints(String clusterEndpoint,
                                                String readerEndpoint,
-                                               Collection<NeptuneInstanceProperties> instances) {
+                                               Collection<NeptuneInstanceMetadata> instances) {
             return instances.stream()
-                    .filter(NeptuneInstanceProperties::isAvailable)
-                    .map(NeptuneInstanceProperties::getEndpoint)
+                    .filter(NeptuneInstanceMetadata::isAvailable)
+                    .map(NeptuneInstanceMetadata::getEndpoint)
                     .collect(Collectors.toList());
         }
     },
@@ -37,11 +37,11 @@ public enum EndpointsType implements EndpointsSelector {
         @Override
         public Collection<String> getEndpoints(String clusterEndpoint,
                                                String readerEndpoint,
-                                               Collection<NeptuneInstanceProperties> instances) {
+                                               Collection<NeptuneInstanceMetadata> instances) {
             List<String> results = instances.stream()
-                    .filter(NeptuneInstanceProperties::isPrimary)
-                    .filter(NeptuneInstanceProperties::isAvailable)
-                    .map(NeptuneInstanceProperties::getEndpoint)
+                    .filter(NeptuneInstanceMetadata::isPrimary)
+                    .filter(NeptuneInstanceMetadata::isAvailable)
+                    .map(NeptuneInstanceMetadata::getEndpoint)
                     .collect(Collectors.toList());
 
             if (results.isEmpty()){
@@ -56,12 +56,12 @@ public enum EndpointsType implements EndpointsSelector {
         @Override
         public Collection<String> getEndpoints(String clusterEndpoint,
                                                String readerEndpoint,
-                                               Collection<NeptuneInstanceProperties> instances) {
+                                               Collection<NeptuneInstanceMetadata> instances) {
 
             List<String> results = instances.stream()
-                    .filter(NeptuneInstanceProperties::isReader)
-                    .filter(NeptuneInstanceProperties::isAvailable)
-                    .map(NeptuneInstanceProperties::getEndpoint)
+                    .filter(NeptuneInstanceMetadata::isReader)
+                    .filter(NeptuneInstanceMetadata::isAvailable)
+                    .map(NeptuneInstanceMetadata::getEndpoint)
                     .collect(Collectors.toList());
 
             if (results.isEmpty()) {
@@ -76,7 +76,7 @@ public enum EndpointsType implements EndpointsSelector {
         @Override
         public Collection<String> getEndpoints(String clusterEndpoint,
                                                String readerEndpoint,
-                                               Collection<NeptuneInstanceProperties> instances) {
+                                               Collection<NeptuneInstanceMetadata> instances) {
 
             return Collections.singletonList(clusterEndpoint);
         }
@@ -85,7 +85,7 @@ public enum EndpointsType implements EndpointsSelector {
         @Override
         public Collection<String> getEndpoints(String clusterEndpoint,
                                                String readerEndpoint,
-                                               Collection<NeptuneInstanceProperties> instances) {
+                                               Collection<NeptuneInstanceMetadata> instances) {
 
             return Collections.singletonList(readerEndpoint);
         }

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/GetEndpointsFromNeptuneManagementApi.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/GetEndpointsFromNeptuneManagementApi.java
@@ -27,18 +27,20 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-public class GetEndpointsFromNeptuneManagementApi implements ClusterEndpointsFetchStrategy {
+public class GetEndpointsFromNeptuneManagementApi implements
+        ClusterEndpointsFetchStrategy,
+        ClusterMetadataFetchStrategy {
 
     private static final Logger logger = LoggerFactory.getLogger(GetEndpointsFromNeptuneManagementApi.class);
 
     private static final Map<String, Map<String, String>> instanceTags = new HashMap<>();
-
     private final String clusterId;
     private final String region;
     private final String iamProfile;
     private final AWSCredentialsProvider credentials;
     private final Collection<EndpointsSelector> selectors;
     private final AtomicReference<Map<EndpointsSelector, Collection<String>>> previousResults = new AtomicReference<>();
+    private final AtomicReference<NeptuneClusterMetadata> previousClusterMetadata = new AtomicReference<>();
 
     public GetEndpointsFromNeptuneManagementApi(String clusterId, Collection<EndpointsSelector> selectors) {
         this(clusterId, selectors, RegionUtils.getCurrentRegionName());
@@ -65,10 +67,10 @@ public class GetEndpointsFromNeptuneManagementApi implements ClusterEndpointsFet
     }
 
     private GetEndpointsFromNeptuneManagementApi(String clusterId,
-                                                Collection<EndpointsSelector> selectors,
-                                                String region,
-                                                String iamProfile,
-                                                AWSCredentialsProvider credentials) {
+                                                 Collection<EndpointsSelector> selectors,
+                                                 String region,
+                                                 String iamProfile,
+                                                 AWSCredentialsProvider credentials) {
         this.clusterId = clusterId;
         this.selectors = selectors;
         this.region = region;
@@ -77,18 +79,17 @@ public class GetEndpointsFromNeptuneManagementApi implements ClusterEndpointsFet
     }
 
     @Override
-    public Map<EndpointsSelector, Collection<String>> getAddresses() {
-
+    public NeptuneClusterMetadata getClusterMetadata() {
         try {
             AmazonNeptuneClientBuilder builder = AmazonNeptuneClientBuilder.standard();
 
-            if (StringUtils.isNotEmpty(region)){
+            if (StringUtils.isNotEmpty(region)) {
                 builder = builder.withRegion(region);
             }
 
-            if (credentials != null){
+            if (credentials != null) {
                 builder = builder.withCredentials(credentials);
-            } else if (!iamProfile.equals(IamAuthConfig.DEFAULT_PROFILE)){
+            } else if (!iamProfile.equals(IamAuthConfig.DEFAULT_PROFILE)) {
                 builder = builder.withCredentials(new ProfileCredentialsProvider(iamProfile));
             }
 
@@ -126,7 +127,7 @@ public class GetEndpointsFromNeptuneManagementApi implements ClusterEndpointsFet
             DescribeDBInstancesResult describeDBInstancesResult = neptune
                     .describeDBInstances(describeDBInstancesRequest);
 
-            Collection<NeptuneInstanceProperties> instances = new ArrayList<>();
+            Collection<NeptuneInstanceMetadata> instances = new ArrayList<>();
             describeDBInstancesResult.getDBInstances()
                     .forEach(c -> {
                                 String role = "unknown";
@@ -137,35 +138,30 @@ public class GetEndpointsFromNeptuneManagementApi implements ClusterEndpointsFet
                                     role = "reader";
                                 }
                                 instances.add(
-                                        new NeptuneInstanceProperties(
-                                                c.getDBInstanceIdentifier(),
-                                                role,
-                                                c.getEndpoint().getAddress(),
-                                                c.getDBInstanceStatus(),
-                                                c.getAvailabilityZone(),
-                                                c.getDBInstanceClass(),
-                                                getTags(c.getDBInstanceArn(), neptune)));
+                                        new NeptuneInstanceMetadata()
+                                                .withInstanceId(c.getDBInstanceIdentifier())
+                                                .withRole(role)
+                                                .withEndpoint(c.getEndpoint().getAddress())
+                                                .withStatus(c.getDBInstanceStatus())
+                                                .withAvailabilityZone(c.getAvailabilityZone())
+                                                .withInstanceType(c.getDBInstanceClass())
+                                                .withTags(getTags(c.getDBInstanceArn(), neptune)));
                             }
                     );
 
             neptune.shutdown();
 
-            Map<EndpointsSelector, Collection<String>> results = new HashMap<>();
-
-            for (EndpointsSelector selector : selectors) {
-                results.put(selector, selector.getEndpoints(clusterEndpoint, readerEndpoint, instances));
-            }
-
-            previousResults.set(results);
-
-            return results;
+            return new NeptuneClusterMetadata()
+                    .withInstances(instances)
+                    .withClusterEndpoint(clusterEndpoint)
+                    .withReaderEndpoint(readerEndpoint);
 
         } catch (AmazonNeptuneException e) {
             if (e.getErrorCode().equals("Throttling")) {
-                Map<EndpointsSelector, Collection<String>> results = previousResults.get();
-                if (results != null) {
-                    logger.warn("Calls to the Neptune Management API are being throttled. Reduce the refresh rate and stagger refresh agent requests, or use a NeptuneEndpointsInfoLambda proxy.");
-                    return results;
+                logger.warn("Calls to the Neptune Management API are being throttled. Reduce the refresh rate and stagger refresh agent requests, or use a NeptuneEndpointsInfoLambda proxy.");
+                NeptuneClusterMetadata previous = previousClusterMetadata.get();
+                if (previous != null) {
+                    return previous;
                 } else {
                     throw e;
                 }
@@ -173,6 +169,24 @@ public class GetEndpointsFromNeptuneManagementApi implements ClusterEndpointsFet
                 throw e;
             }
         }
+
+    }
+
+    @Override
+    public Map<EndpointsSelector, Collection<String>> getAddresses() {
+
+        NeptuneClusterMetadata clusterMetadata = getClusterMetadata();
+
+        Map<EndpointsSelector, Collection<String>> results = new HashMap<>();
+
+        for (EndpointsSelector selector : selectors) {
+            results.put(selector, selector.getEndpoints(
+                    clusterMetadata.getClusterEndpoint(),
+                    clusterMetadata.getReaderEndpoint(),
+                    clusterMetadata.getInstances()));
+        }
+
+        return results;
     }
 
     private Map<String, String> getTags(String dbInstanceArn, AmazonNeptune neptune) {

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneClusterMetadata.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneClusterMetadata.java
@@ -1,0 +1,78 @@
+package software.amazon.neptune.cluster;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class NeptuneClusterMetadata {
+
+    public static NeptuneClusterMetadata fromByeArray(byte[] bytes) throws IOException {
+        return new ObjectMapper().readerFor(NeptuneClusterMetadata.class).readValue(bytes);
+    }
+
+    private final Collection<NeptuneInstanceMetadata> instances = new ArrayList<>();
+    private String clusterEndpoint;
+    private String readerEndpoint;
+
+    public NeptuneClusterMetadata(){
+
+    }
+
+    public void setClusterEndpoint(String clusterEndpoint) {
+        this.clusterEndpoint = clusterEndpoint;
+    }
+
+    public void setReaderEndpoint(String readerEndpoint) {
+        this.readerEndpoint = readerEndpoint;
+    }
+
+    public void setInstances(Collection<NeptuneInstanceMetadata> instances) {
+        this.instances.clear();
+        this.instances.addAll(instances);
+    }
+
+    public NeptuneClusterMetadata withClusterEndpoint(String clusterEndpoint) {
+        setClusterEndpoint(clusterEndpoint);
+        return this;
+    }
+
+    public NeptuneClusterMetadata withReaderEndpoint(String readerEndpoint) {
+        setReaderEndpoint(readerEndpoint);
+        return this;
+    }
+
+    public NeptuneClusterMetadata withInstances(Collection<NeptuneInstanceMetadata> instances) {
+        setInstances(instances);
+        return this;
+    }
+
+
+    public Collection<NeptuneInstanceMetadata> getInstances() {
+        return instances;
+    }
+
+    public String getClusterEndpoint() {
+        return clusterEndpoint;
+    }
+
+    public String getReaderEndpoint() {
+        return readerEndpoint;
+    }
+
+    @Override
+    public String toString() {
+        return "NeptuneClusterMetadata{" +
+                "instances=" + instances +
+                ", clusterEndpoint='" + clusterEndpoint + '\'' +
+                ", readerEndpoint='" + readerEndpoint + '\'' +
+                '}';
+    }
+
+    public String toJsonString() throws JsonProcessingException {
+        return new ObjectMapper().writerFor(this.getClass()).writeValueAsString(this);
+    }
+}

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneInstanceMetadata.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneInstanceMetadata.java
@@ -12,33 +12,88 @@ permissions and limitations under the License.
 
 package software.amazon.neptune.cluster;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.util.HashMap;
 import java.util.Map;
 
-public class NeptuneInstanceProperties {
+public class NeptuneInstanceMetadata {
 
-    private final String instanceId;
-    private final String role;
-    private final String endpoint;
-    private final String status;
-    private final String availabilityZone;
-    private final String instanceType;
+    private String instanceId;
+    private String role;
+    private String endpoint;
+    private String status;
+    private String availabilityZone;
+    private String instanceType;
 
-    private final Map<String, String> tags;
+    private final Map<String, String> tags = new HashMap<>();
 
-    public NeptuneInstanceProperties(String instanceId,
-                                     String role,
-                                     String endpoint,
-                                     String status,
-                                     String availabilityZone,
-                                     String instanceType,
-                                     Map<String, String> tags) {
+    public NeptuneInstanceMetadata(){
+
+    }
+
+    public void setInstanceId(String instanceId) {
         this.instanceId = instanceId;
+    }
+
+    public void setRole(String role) {
         this.role = role;
+    }
+
+    public void setEndpoint(String endpoint) {
         this.endpoint = endpoint;
+    }
+
+    public void setStatus(String status) {
         this.status = status;
+    }
+
+    public void setAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
+    }
+
+    public void setInstanceType(String instanceType) {
         this.instanceType = instanceType;
-        this.tags = tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags.clear();
+        this.tags.putAll(tags);
+    }
+
+    public NeptuneInstanceMetadata withInstanceId(String instanceId) {
+        setInstanceId(instanceId);
+        return this;
+    }
+
+    public NeptuneInstanceMetadata withRole(String role) {
+        setRole(role);
+        return this;
+    }
+
+    public NeptuneInstanceMetadata withEndpoint(String endpoint) {
+        setEndpoint(endpoint);
+        return this;
+    }
+
+    public NeptuneInstanceMetadata withStatus(String status) {
+        setStatus(status);
+        return this;
+    }
+
+    public NeptuneInstanceMetadata withAvailabilityZone(String availabilityZone) {
+        setAvailabilityZone(availabilityZone);
+        return this;
+    }
+
+    public NeptuneInstanceMetadata withInstanceType(String instanceType) {
+        setInstanceType(instanceType);
+        return this;
+    }
+
+    public NeptuneInstanceMetadata withTags(Map<String, String> tags) {
+        setTags(tags);
+        return this;
     }
 
     public String getInstanceId() {
@@ -65,6 +120,10 @@ public class NeptuneInstanceProperties {
         return instanceType;
     }
 
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
     public boolean hasTag(String tag){
         return tags.containsKey(tag);
     }
@@ -84,14 +143,17 @@ public class NeptuneInstanceProperties {
         return hasTag(tag) && getTag(tag).equals(value);
     }
 
+    @JsonIgnore
     public boolean isAvailable(){
         return getStatus().equalsIgnoreCase("Available");
     }
 
+    @JsonIgnore
     public boolean isPrimary() {
         return getRole().equalsIgnoreCase("writer");
     }
 
+    @JsonIgnore
     public boolean isReader() {
         return getRole().equalsIgnoreCase("reader");
     }

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/OnNewClusterMetadata.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/OnNewClusterMetadata.java
@@ -1,0 +1,8 @@
+package software.amazon.neptune.cluster;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface OnNewClusterMetadata {
+    void apply(NeptuneClusterMetadata neptuneClusterMetadata);
+}

--- a/neptune-gremlin-client/gremlin-client/src/test/java/software/amazon/neptune/cluster/GetEndpointsFromNeptuneManagementApiTest.java
+++ b/neptune-gremlin-client/gremlin-client/src/test/java/software/amazon/neptune/cluster/GetEndpointsFromNeptuneManagementApiTest.java
@@ -1,0 +1,15 @@
+package software.amazon.neptune.cluster;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class GetEndpointsFromNeptuneManagementApiTest {
+    @Test
+    public void implementsClusterMetadataFetchStrategy(){
+        ClusterEndpointsFetchStrategy command =
+                new GetEndpointsFromNeptuneManagementApi("clusterId", Arrays.asList(EndpointsType.ClusterEndpoint));
+        Assert.assertTrue(ClusterMetadataFetchStrategy.class.isAssignableFrom(command.getClass()));
+    }
+}

--- a/neptune-gremlin-client/gremlin-client/src/test/java/software/amazon/neptune/cluster/NeptuneClusterMetadataTest.java
+++ b/neptune-gremlin-client/gremlin-client/src/test/java/software/amazon/neptune/cluster/NeptuneClusterMetadataTest.java
@@ -1,0 +1,48 @@
+package software.amazon.neptune.cluster;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class NeptuneClusterMetadataTest {
+
+    @Test
+    public void serializeAndDeserializeClusterMetadata() throws IOException {
+        HashMap<String, String> tags = new HashMap<>();
+        tags.put("name", "my-writer");
+        tags.put("app", "analytics");
+
+        NeptuneInstanceMetadata instance1 = new NeptuneInstanceMetadata()
+                .withInstanceId("instance-1")
+                .withInstanceType("r5.large")
+                .withAvailabilityZone("eu-west-1b")
+                .withEndpoint("endpoint-1")
+                .withStatus("available")
+                .withRole("writer")
+                .withTags(tags);
+
+        NeptuneInstanceMetadata instance2 = new NeptuneInstanceMetadata()
+                .withInstanceId("instance-2")
+                .withInstanceType("r5.medium")
+                .withAvailabilityZone("eu-west-1a")
+                .withEndpoint("endpoint-2")
+                .withStatus("rebooting")
+                .withRole("reader")
+                .withTags(tags);
+
+        NeptuneClusterMetadata neptuneClusterMetadata = new NeptuneClusterMetadata()
+                .withClusterEndpoint("cluster-endpoint")
+                .withReaderEndpoint("reader-endpoint")
+                .withInstances(Arrays.asList(instance1, instance2));
+
+        String json1 = neptuneClusterMetadata.toJsonString();
+        NeptuneClusterMetadata cluster = NeptuneClusterMetadata.fromByeArray(json1.getBytes());
+        String json2 = cluster.toJsonString();
+
+        Assert.assertEquals(json2, json1);
+    }
+
+}

--- a/neptune-gremlin-client/neptune-endpoints-info-lambda/pom.xml
+++ b/neptune-gremlin-client/neptune-endpoints-info-lambda/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>neptune-gremlin-client</artifactId>
         <groupId>software.amazon.neptune</groupId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,6 +50,12 @@
             <groupId>software.amazon.neptune</groupId>
             <artifactId>gremlin-client</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/neptune-gremlin-client/pom.xml
+++ b/neptune-gremlin-client/pom.xml
@@ -7,7 +7,7 @@
     <groupId>software.amazon.neptune</groupId>
     <artifactId>neptune-gremlin-client</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/neptune-gremlin-client/readme.md
+++ b/neptune-gremlin-client/readme.md
@@ -6,6 +6,8 @@ The client also provides support for IAM database authentication, and for connec
 
 If your application uses a lot of concurrent clients, you should proxy endpoint refresh requests through a Lambda function that periodically queries the Management API and then caches the results on behalf of your clients. This repository includes an AWS Lambda function that can act as a Neptune endpoints information proxy.
 
+  - **[New November 2022]** The `ClusterEndpointsRefreshAgent.lambdaProxy()` factory method, which creates a `ClusterEndpointsRefreshAgent` that queries an endpoints AWS Lambda proxy, now accepts a custom `EndpointsSelector`, allowing you to use custom endpoint selection strategies with the Lambda proxy.
+
   - **[New May 24 2022 – version 1.0.6]** Upgraded to version 3.5.2 of the Java Gremlin driver.
   
   - **[New May 24 2022 – version 1.0.5]** Upgraded to version 3.4.13 of the Java Gremlin driver.
@@ -80,28 +82,9 @@ GremlinCluster cluster = GremlinClusterBuilder.build()
 GremlinClient client = cluster.connect();
 
 refreshAgent.startPollingNeptuneAPI(
-        addresses -> client.refreshEndpoints(addresses.get(selector)),
+        (OnNewAddresses) addresses -> client.refreshEndpoints(addresses.get(selector)),
         60,
         TimeUnit.SECONDS);
-```
-
-### Connect the ClusterEndpointsRefreshAgent to a Lambda Proxy when you have many clients
-
-If the Neptune Management API experiences a high rate of requests, it will start throttling API calls. If you have a lot of clients frequently polling for endpoint information, your application can very quickly experience throttling (in the form of HTTP 400 throttling exceptions).
-
-Because of this throttling behaviour, if your application uses a lot of concurrent `GremlinClient` and `ClusterEndpointsRefreshAgent` instances, instead of querying the Management API directly, you should proxy endpoint refresh requests through a Lambda function that periodically queries the Management API and then caches the results on behalf of its clients.
-
-This repository includes an AWS CloudFormation template that creates a Lambda function which polls the Management API, and which you can configure with a Neptune database cluster ID and a polling interval. After it’s deployed, this function is named _neptune-endpoint-info_<cluster-id>_. In your application code, you can then create a `ClusterEndpointsRefreshAgent` using the `lambdaProxy()` factory method, supplying the type of endpoint information to be retrieved (`All`, `Primary`, `ReadReplicas`, `ClusterEndpoint` or `ReaderEndpoint` – see the `EndpointsType` below), the name of the proxy Lambda function, and the AWS Region in which the proxy Lambda function is located.
-
-The identity under which you're running your aoplication must be authorized to perform `lambda:Invoke` for your proxy Lambda function.
-
-The following code shows how to create a refresh agent that gets endpoint information from a proxy Lambda function named _neptune-endpoint-info_my-cluster_:
-
-```
-ClusterEndpointsRefreshAgent refreshAgent = ClusterEndpointsRefreshAgent.lambdaProxy(
-    EndpointsType.ReadReplicas,
-    "neptune-endpoint-info_my-cluster",
-    "eu-west-1");
 ```
 
 ### EndpointsSelector
@@ -130,7 +113,7 @@ GremlinCluster cluster = GremlinClusterBuilder.build()
 GremlinClient client = cluster.connect();
 
 refreshAgent.startPollingNeptuneAPI(
-    addresses -> client.refreshEndpoints(addresses.get(selector)),
+    (OnNewAddresses) addresses -> client.refreshEndpoints(addresses.get(selector)),
     60,
     TimeUnit.SECONDS);
 ```
@@ -143,7 +126,67 @@ The `EndpointsType` enum provides implementations of `EndpointsSelector` for som
   * `EndpointsType.ClusterEndpoint` – returns the cluster endpoint
   * `EndpointsType.ReaderEndpoint` – return the reader endpoint
 
+### Connect the ClusterEndpointsRefreshAgent to a Lambda Proxy when you have many clients
 
+When the Neptune Management API experiences a high rate of requests, it starts throttling API calls. If you have a lot of clients frequently polling for endpoint information, your application can very quickly experience throttling (in the form of HTTP 400 throttling exceptions).
+
+Because of this throttling behaviour, if your application uses a lot of concurrent `GremlinClient` and `ClusterEndpointsRefreshAgent` instances, instead of querying the Management API directly, you should proxy endpoint refresh requests through an AWS Lambda function. The Lambda function can periodically query the Management API and then cache the results on behalf of its clients.
+
+This repository includes an AWS CloudFormation template that creates a Lambda function which polls the Management API, and which you can configure with a Neptune database cluster ID and a polling interval. After it's deployed, this function is named _neptune-endpoint-info_<cluster-id>_. In your application code, you can then create a `ClusterEndpointsRefreshAgent` using the `lambdaProxy()` factory method, supplying the type of endpoint information to be retrieved (for example, `All`, `Primary`, `ReadReplicas`, `ClusterEndpoint` or `ReaderEndpoint`), the name of the proxy Lambda function, and the AWS Region in which the proxy Lambda function is located.
+
+The identity under which you're running your aoplication must be authorized to perform `lambda:Invoke` for your proxy Lambda function.
+
+The following code shows how to create a refresh agent that gets endpoint information from a proxy Lambda function named _neptune-endpoint-info_my-cluster_:
+
+```
+ClusterEndpointsRefreshAgent refreshAgent = ClusterEndpointsRefreshAgent.lambdaProxy(
+    EndpointsType.ReadReplicas,
+    "neptune-endpoint-info_my-cluster",
+    "eu-west-1");
+	
+GremlinCluster cluster = GremlinClusterBuilder.build()
+    .enableSsl(true)
+    .addContactPoints(refreshAgent.getAddresses())
+    .port(8182)
+    .create();
+
+GremlinClient client = cluster.connect();
+
+refreshAgent.startPollingNeptuneAPI(
+    (OnNewAddresses) addresses -> client.refreshEndpoints(addresses.get(selector)),
+    60,
+    TimeUnit.SECONDS);
+```
+
+You can also supply a custom endpoints selector when using the Lambda proxy:
+
+```
+EndpointsSelector selector = (clusterEndpoint, readerEndpoint, instances) ->
+    instances.stream()
+        .filter(NeptuneInstanceProperties::isReader)
+        .filter(i -> i.hasTag("workload", "analytics"))
+        .filter(NeptuneInstanceProperties::isAvailable)
+        .map(NeptuneInstanceProperties::getEndpoint)
+        .collect(Collectors.toList());
+
+ClusterEndpointsRefreshAgent refreshAgent = ClusterEndpointsRefreshAgent.lambdaProxy(
+    selector,
+    "neptune-endpoint-info_my-cluster",
+    "eu-west-1");
+
+GremlinCluster cluster = GremlinClusterBuilder.build()
+    .enableSsl(true)
+    .addContactPoints(refreshAgent.getAddresses())
+    .port(8182)
+    .create();
+
+GremlinClient client = cluster.connect();
+
+refreshAgent.startPollingNeptuneAPI(
+    (OnNewAddresses) addresses -> client.refreshEndpoints(addresses.get(selector)),
+    60,
+    TimeUnit.SECONDS);
+```
 
 ## GremlinClusterBuilder and NeptuneGremlinClusterBuilder
 
@@ -265,7 +308,7 @@ GremlinCluster cluster = GremlinClusterBuilder.build()
 GremlinClient client = cluster.connect();
 
 refreshAgent.startPollingNeptuneAPI(
-    addresses -> client.refreshEndpoints(addresses.get(selector)),
+    (OnNewAddresses) addresses -> client.refreshEndpoints(addresses.get(selector)),
     60,
     TimeUnit.SECONDS);
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change adds support for using custom endpoint selectors with a ClusterEndpointsRefreshAgent querying an AWS Lambda endpoints proxy. Previously, when using a ClusterEndpointsRefreshAgent with a Lambda proxy, you could only select endpoints using an EndpointsType enum. Now, with custom selector support, you can get a list of instances in your cluster from the Lambda proxy based on tags, instance types, instance IDs, AZs, etc.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
