### PR TITLE
Check for null endpoints on instance metadata.

### DIFF
--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/GetEndpointsFromNeptuneManagementApi.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/GetEndpointsFromNeptuneManagementApi.java
@@ -137,11 +137,12 @@ public class GetEndpointsFromNeptuneManagementApi implements
                                 if (replicas.contains(c.getDBInstanceIdentifier())) {
                                     role = "reader";
                                 }
+                                String address = c.getEndpoint() == null ? null : c.getEndpoint().getAddress();
                                 instances.add(
                                         new NeptuneInstanceMetadata()
                                                 .withInstanceId(c.getDBInstanceIdentifier())
                                                 .withRole(role)
-                                                .withEndpoint(c.getEndpoint().getAddress())
+                                                .withEndpoint(address)
                                                 .withStatus(c.getDBInstanceStatus())
                                                 .withAvailabilityZone(c.getAvailabilityZone())
                                                 .withInstanceType(c.getDBInstanceClass())

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneInstanceMetadata.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneInstanceMetadata.java
@@ -145,7 +145,7 @@ public class NeptuneInstanceMetadata {
 
     @JsonIgnore
     public boolean isAvailable(){
-        return getStatus().equalsIgnoreCase("Available");
+        return getStatus().equalsIgnoreCase("Available") && endpoint != null;
     }
 
     @JsonIgnore


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Instance info return by DescribeDbInstances that are in a 'creating' state may not have an endpoint. This fix checks for null endpoints when creating NeptuneInstanceMetadata from a DescribeDbInstancesResult.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
