### PR TITLE
Improve inferring cluster ID from endpoint

### DIFF
--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/CreatePropertyGraphExportConfig.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/CreatePropertyGraphExportConfig.java
@@ -47,7 +47,7 @@ import java.util.Collection;
 public class CreatePropertyGraphExportConfig extends NeptuneExportCommand implements Runnable {
 
     @Inject
-    private CloneClusterModule cloneStrategy = new CloneClusterModule(awsCli);
+    private CloneClusterModule cloneStrategy = new CloneClusterModule();
 
     @Inject
     private CommonConnectionModule connection = new CommonConnectionModule(awsCli);
@@ -75,7 +75,11 @@ public class CreatePropertyGraphExportConfig extends NeptuneExportCommand implem
 
         try {
             Timer.timedActivity("creating property graph config", (CheckedActivity.Runnable) () -> {
-                try (Cluster cluster = cloneStrategy.cloneCluster(connection.config(), concurrency.config(sampling.isFullScan()), featureToggles())) {
+                try (Cluster cluster = cloneStrategy.cloneCluster(
+                        connection.clusterMetadata(),
+                        connection.config(),
+                        concurrency.config(sampling.isFullScan()),
+                        featureToggles())) {
 
                     if (sampling.isFullScan()) {
 

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraph.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraph.java
@@ -52,7 +52,7 @@ import java.util.Collection;
 public class ExportPropertyGraph extends NeptuneExportCommand implements Runnable {
 
     @Inject
-    private CloneClusterModule cloneStrategy = new CloneClusterModule(awsCli);
+    private CloneClusterModule cloneStrategy = new CloneClusterModule();
 
     @Inject
     private CommonConnectionModule connection = new CommonConnectionModule(awsCli);
@@ -89,7 +89,11 @@ public class ExportPropertyGraph extends NeptuneExportCommand implements Runnabl
 
         try {
             Timer.timedActivity("exporting property graph", (CheckedActivity.Runnable) () -> {
-                try (Cluster cluster = cloneStrategy.cloneCluster(connection.config(), concurrency.config(), featureToggles())) {
+                try (Cluster cluster = cloneStrategy.cloneCluster(
+                        connection.clusterMetadata(),
+                        connection.config(),
+                        concurrency.config(),
+                        featureToggles())) {
 
                     Directories directories = target.createDirectories();
 

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraphFromConfig.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraphFromConfig.java
@@ -42,7 +42,7 @@ import java.util.Collection;
 public class ExportPropertyGraphFromConfig extends NeptuneExportCommand implements Runnable {
 
     @Inject
-    private CloneClusterModule cloneStrategy = new CloneClusterModule(awsCli);
+    private CloneClusterModule cloneStrategy = new CloneClusterModule();
 
     @Inject
     private CommonConnectionModule connection = new CommonConnectionModule(awsCli);
@@ -76,7 +76,11 @@ public class ExportPropertyGraphFromConfig extends NeptuneExportCommand implemen
 
         try {
             Timer.timedActivity("exporting property graph from config", (CheckedActivity.Runnable) () -> {
-                try (Cluster cluster = cloneStrategy.cloneCluster(connection.config(), concurrency.config(), featureToggles())) {
+                try (Cluster cluster = cloneStrategy.cloneCluster(
+                        connection.clusterMetadata(),
+                        connection.config(),
+                        concurrency.config(),
+                        featureToggles())) {
 
                     Directories directories = target.createDirectories();
                     JsonResource<GraphSchema> configFileResource = directories.configFileResource();

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraphFromGremlinQueries.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraphFromGremlinQueries.java
@@ -47,7 +47,7 @@ import java.util.List;
 public class ExportPropertyGraphFromGremlinQueries extends NeptuneExportCommand implements Runnable {
 
     @Inject
-    private CloneClusterModule cloneStrategy = new CloneClusterModule(awsCli);
+    private CloneClusterModule cloneStrategy = new CloneClusterModule();
 
     @Inject
     private CommonConnectionModule connection = new CommonConnectionModule(awsCli);
@@ -86,7 +86,11 @@ public class ExportPropertyGraphFromGremlinQueries extends NeptuneExportCommand 
 
         try {
             Timer.timedActivity("exporting property graph from queries", (CheckedActivity.Runnable) () -> {
-                try (Cluster cluster = cloneStrategy.cloneCluster(connection.config(), concurrency.config(), featureToggles())) {
+                try (Cluster cluster = cloneStrategy.cloneCluster(
+                        connection.clusterMetadata(),
+                        connection.config(),
+                        concurrency.config(),
+                        featureToggles())) {
 
                     Directories directories = target.createDirectories(DirectoryStructure.GremlinQueries);
                     JsonResource<NamedQueriesCollection> queriesResource = queriesFile != null ?

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportRdfGraph.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/ExportRdfGraph.java
@@ -18,7 +18,6 @@ import com.amazonaws.services.neptune.cluster.ConcurrencyConfig;
 import com.amazonaws.services.neptune.cluster.EventId;
 import com.amazonaws.services.neptune.cluster.GetLastEventIdStrategy;
 import com.amazonaws.services.neptune.io.Directories;
-import com.amazonaws.services.neptune.io.DirectoryStructure;
 import com.amazonaws.services.neptune.propertygraph.ExportStats;
 import com.amazonaws.services.neptune.propertygraph.io.JsonResource;
 import com.amazonaws.services.neptune.rdf.NeptuneSparqlClient;
@@ -40,7 +39,7 @@ import javax.inject.Inject;
 public class ExportRdfGraph extends NeptuneExportCommand implements Runnable {
 
     @Inject
-    private CloneClusterModule cloneStrategy = new CloneClusterModule(awsCli);
+    private CloneClusterModule cloneStrategy = new CloneClusterModule();
 
     @Inject
     private CommonConnectionModule connection = new CommonConnectionModule(awsCli);
@@ -59,7 +58,11 @@ public class ExportRdfGraph extends NeptuneExportCommand implements Runnable {
 
         try {
             Timer.timedActivity(String.format("exporting rdf %s", exportScope.scope()), (CheckedActivity.Runnable) () -> {
-                try (Cluster cluster = cloneStrategy.cloneCluster(connection.config(), new ConcurrencyConfig(1), featureToggles())) {
+                try (Cluster cluster = cloneStrategy.cloneCluster(
+                        connection.clusterMetadata(),
+                        connection.config(),
+                        new ConcurrencyConfig(1),
+                        featureToggles())) {
 
                     Directories directories = target.createDirectories();
 

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/RemoveClone.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/RemoveClone.java
@@ -13,14 +13,13 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune;
 
 import com.amazonaws.services.neptune.cli.AwsCliModule;
-import com.amazonaws.services.neptune.cli.CloneClusterModule;
 import com.amazonaws.services.neptune.cluster.GetClusterIdFromCorrelationId;
+import com.amazonaws.services.neptune.cluster.NeptuneClusterMetadata;
 import com.amazonaws.services.neptune.cluster.RemoveCloneTask;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.Once;
 import com.github.rvesse.airline.annotations.restrictions.RequireOnlyOne;
-import com.github.rvesse.airline.annotations.restrictions.Required;
 import org.apache.commons.lang.StringUtils;
 
 import javax.inject.Inject;
@@ -44,16 +43,16 @@ public class RemoveClone implements Runnable {
     @Override
     public void run() {
 
-        if (StringUtils.isEmpty(cloneClusterId) && StringUtils.isNotEmpty(correlationId)){
+        if (StringUtils.isEmpty(cloneClusterId) && StringUtils.isNotEmpty(correlationId)) {
             cloneClusterId = new GetClusterIdFromCorrelationId(correlationId, awsCli).execute();
-            if (StringUtils.isEmpty(cloneClusterId)){
+            if (StringUtils.isEmpty(cloneClusterId)) {
                 System.err.println(String.format("Unable to get a cloned Amazon Neptune database cluster ID for correlation ID %s", correlationId));
                 System.exit(0);
             }
         }
 
         try {
-            new RemoveCloneTask(cloneClusterId, awsCli).execute();
+            new RemoveCloneTask(NeptuneClusterMetadata.createFromClusterId(cloneClusterId, awsCli)).execute();
         } catch (Exception e) {
             System.err.println("An error occurred while removing a cloned Amazon Neptune database cluster:");
             e.printStackTrace();

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/cli/CloneClusterModule.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/cli/CloneClusterModule.java
@@ -12,7 +12,6 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.cli;
 
-import com.amazonaws.services.neptune.AmazonNeptune;
 import com.amazonaws.services.neptune.cluster.*;
 import com.amazonaws.services.neptune.export.FeatureToggle;
 import com.amazonaws.services.neptune.export.FeatureToggles;
@@ -20,8 +19,6 @@ import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.AllowedValues;
 import com.github.rvesse.airline.annotations.restrictions.Once;
 import com.github.rvesse.airline.annotations.restrictions.ranges.IntegerRange;
-
-import java.util.function.Supplier;
 
 public class CloneClusterModule {
 
@@ -75,33 +72,33 @@ public class CloneClusterModule {
     @Once
     private String cloneCorrelationId;
 
-    private final Supplier<AmazonNeptune> amazonNeptuneClientSupplier;
 
-    public CloneClusterModule(Supplier<AmazonNeptune> amazonNeptuneClientSupplier) {
-        this.amazonNeptuneClientSupplier = amazonNeptuneClientSupplier;
+    public CloneClusterModule() {
     }
 
-    public Cluster cloneCluster(ConnectionConfig connectionConfig, ConcurrencyConfig concurrencyConfig, FeatureToggles featureToggles) throws Exception {
+    public Cluster cloneCluster(NeptuneClusterMetadata clusterMetadata,
+                                ConnectionConfig connectionConfig,
+                                ConcurrencyConfig concurrencyConfig,
+                                FeatureToggles featureToggles) throws Exception {
 
-        NeptuneClusterMetadata originalClusterMetadata = NeptuneClusterMetadata.createFromClusterId(connectionConfig.clusterId(), amazonNeptuneClientSupplier);
-        originalClusterMetadata.printDetails();
+        clusterMetadata.printDetails();
 
-        if (cloneCluster){
-            if (featureToggles.containsFeature(FeatureToggle.Simulate_Cloned_Cluster)){
-                return new SimulatedCloneCluster(amazonNeptuneClientSupplier).cloneCluster(connectionConfig, concurrencyConfig);
+        if (cloneCluster) {
+            if (featureToggles.containsFeature(FeatureToggle.Simulate_Cloned_Cluster)) {
+                return new SimulatedCloneCluster(clusterMetadata).cloneCluster(connectionConfig, concurrencyConfig);
             } else {
 
                 CloneCluster command = new CloneCluster(
+                        clusterMetadata,
                         cloneClusterInstanceType,
                         replicaCount,
                         maxConcurrency,
                         engineVersion,
-                        amazonNeptuneClientSupplier,
                         cloneCorrelationId);
                 return command.cloneCluster(connectionConfig, concurrencyConfig);
             }
         } else {
-            return new DoNotCloneCluster(amazonNeptuneClientSupplier).cloneCluster(connectionConfig, concurrencyConfig);
+            return new DoNotCloneCluster(clusterMetadata).cloneCluster(connectionConfig, concurrencyConfig);
         }
     }
 }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/cli/CommonConnectionModule.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/cli/CommonConnectionModule.java
@@ -89,11 +89,18 @@ public class CommonConnectionModule {
         this.amazonNeptuneClientSupplier = amazonNeptuneClientSupplier;
     }
 
+    public NeptuneClusterMetadata clusterMetadata(){
+        if (StringUtils.isNotEmpty(clusterId)) {
+            return NeptuneClusterMetadata.createFromClusterId(clusterId, amazonNeptuneClientSupplier);
+        } else {
+            return NeptuneClusterMetadata.createFromEndpoints(endpoints, amazonNeptuneClientSupplier);
+        }
+    }
+
     public ConnectionConfig config() {
 
         if (StringUtils.isNotEmpty(clusterId)) {
-            NeptuneClusterMetadata clusterMetadata = NeptuneClusterMetadata.createFromClusterId(clusterId, amazonNeptuneClientSupplier);
-            endpoints.addAll(clusterMetadata.endpoints());
+            endpoints.addAll(clusterMetadata().endpoints());
         }
 
         if (endpoints.isEmpty()) {

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
@@ -19,24 +19,24 @@ import java.util.function.Supplier;
 
 public class CloneCluster implements CloneClusterStrategy {
 
+    private final NeptuneClusterMetadata originalClusterMetadata;
     private final String cloneClusterInstanceType;
     private final int replicaCount;
     private final int maxConcurrency;
     private final String engineVersion;
-    private final Supplier<AmazonNeptune> amazonNeptuneClientSupplier;
     private final String cloneCorrelationId;
 
-    public CloneCluster(String cloneClusterInstanceType,
+    public CloneCluster(NeptuneClusterMetadata originalClusterMetadata,
+                        String cloneClusterInstanceType,
                         int replicaCount,
                         int maxConcurrency,
                         String engineVersion,
-                        Supplier<AmazonNeptune> amazonNeptuneClientSupplier,
                         String cloneCorrelationId) {
+        this.originalClusterMetadata = originalClusterMetadata;
         this.cloneClusterInstanceType = cloneClusterInstanceType;
         this.replicaCount = replicaCount;
         this.maxConcurrency = maxConcurrency;
         this.engineVersion = engineVersion;
-        this.amazonNeptuneClientSupplier = amazonNeptuneClientSupplier;
         this.cloneCorrelationId = cloneCorrelationId;
     }
 
@@ -47,7 +47,7 @@ public class CloneCluster implements CloneClusterStrategy {
             throw new IllegalStateException("neptune-export does not support cloning a Neptune cluster accessed via a load balancer");
         }
 
-        String clusterId = connectionConfig.clusterId();
+        String clusterId = originalClusterMetadata.clusterId();
         String targetClusterId = String.format("neptune-export-cluster-%s", UUID.randomUUID().toString().substring(0, 5));
 
         AddCloneTask addCloneTask = new AddCloneTask(
@@ -56,7 +56,7 @@ public class CloneCluster implements CloneClusterStrategy {
                 cloneClusterInstanceType,
                 replicaCount,
                 engineVersion,
-                amazonNeptuneClientSupplier,
+                originalClusterMetadata.clientSupplier(),
                 cloneCorrelationId);
 
         NeptuneClusterMetadata targetClusterMetadata = addCloneTask.execute();
@@ -83,8 +83,8 @@ public class CloneCluster implements CloneClusterStrategy {
                         targetClusterMetadata.isIAMDatabaseAuthenticationEnabled(), true, connectionConfig.proxyConfig()
                 ),
                 new ConcurrencyConfig(newConcurrency),
-                targetClusterMetadata,
-                amazonNeptuneClientSupplier);
+                targetClusterMetadata
+        );
     }
 
     private static class ClonedCluster implements Cluster {
@@ -92,16 +92,13 @@ public class CloneCluster implements CloneClusterStrategy {
         private final ConnectionConfig connectionConfig;
         private final ConcurrencyConfig concurrencyConfig;
         private final NeptuneClusterMetadata clusterMetadata;
-        private final Supplier<AmazonNeptune> amazonNeptuneClientSupplier;
 
         private ClonedCluster(ConnectionConfig connectionConfig,
                               ConcurrencyConfig concurrencyConfig,
-                              NeptuneClusterMetadata clusterMetadata,
-                              Supplier<AmazonNeptune> amazonNeptuneClientSupplier) {
+                              NeptuneClusterMetadata clusterMetadata) {
             this.connectionConfig = connectionConfig;
             this.concurrencyConfig = concurrencyConfig;
             this.clusterMetadata = clusterMetadata;
-            this.amazonNeptuneClientSupplier = amazonNeptuneClientSupplier;
         }
 
         @Override
@@ -115,11 +112,6 @@ public class CloneCluster implements CloneClusterStrategy {
         }
 
         @Override
-        public Supplier<AmazonNeptune> clientSupplier() {
-            return amazonNeptuneClientSupplier;
-        }
-
-        @Override
         public NeptuneClusterMetadata clusterMetadata() {
             return clusterMetadata;
         }
@@ -127,9 +119,7 @@ public class CloneCluster implements CloneClusterStrategy {
         @Override
         public void close() throws Exception {
 
-            RemoveCloneTask removeCloneTask = new RemoveCloneTask(
-                    connectionConfig.clusterId(),
-                    amazonNeptuneClientSupplier);
+            RemoveCloneTask removeCloneTask = new RemoveCloneTask(clusterMetadata);
 
             removeCloneTask.execute();
         }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/Cluster.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/Cluster.java
@@ -19,6 +19,5 @@ import java.util.function.Supplier;
 public interface Cluster extends AutoCloseable {
     ConnectionConfig connectionConfig();
     ConcurrencyConfig concurrencyConfig();
-    Supplier<AmazonNeptune> clientSupplier();
     NeptuneClusterMetadata clusterMetadata();
 }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/ConnectionConfig.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/ConnectionConfig.java
@@ -78,10 +78,4 @@ public class ConnectionConfig {
     public ProxyConfig proxyConfig() {
         return proxyConfig;
     }
-
-    public String clusterId() {
-        return StringUtils.isNotEmpty(clusterId) ?
-                clusterId :
-                NeptuneClusterMetadata.clusterIdFromEndpoint(endpoints().iterator().next());
-    }
 }

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/DoNotCloneCluster.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/DoNotCloneCluster.java
@@ -12,16 +12,12 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.cluster;
 
-import com.amazonaws.services.neptune.AmazonNeptune;
-
-import java.util.function.Supplier;
-
 public class DoNotCloneCluster implements CloneClusterStrategy {
 
-    private final Supplier<AmazonNeptune> clientSupplier;
+    private final NeptuneClusterMetadata clusterMetadata;
 
-    public DoNotCloneCluster(Supplier<AmazonNeptune> clientSupplier) {
-        this.clientSupplier = clientSupplier;
+    public DoNotCloneCluster(NeptuneClusterMetadata clusterMetadata) {
+        this.clusterMetadata = clusterMetadata;
     }
 
     @Override
@@ -39,13 +35,8 @@ public class DoNotCloneCluster implements CloneClusterStrategy {
             }
 
             @Override
-            public Supplier<AmazonNeptune> clientSupplier() {
-                return clientSupplier;
-            }
-
-            @Override
             public NeptuneClusterMetadata clusterMetadata() {
-                return NeptuneClusterMetadata.createFromClusterId(connectionConfig.clusterId(), clientSupplier);
+                return clusterMetadata;
             }
 
             @Override

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/GetLastEventIdTask.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/GetLastEventIdTask.java
@@ -32,11 +32,10 @@ public class GetLastEventIdTask implements GetLastEventIdStrategy{
     @Override
     public void saveLastEventId(String streamEndpointType) throws IOException {
 
-        NeptuneClusterMetadata clusterMetadata = NeptuneClusterMetadata.createFromClusterId(
-                cluster.connectionConfig().clusterId(),
-                cluster.clientSupplier());
-
-        EventId eventId = new GetLastEventId(clusterMetadata, cluster.connectionConfig(), streamEndpointType).execute();
+        EventId eventId = new GetLastEventId(
+                cluster.clusterMetadata(),
+                cluster.connectionConfig(),
+                streamEndpointType).execute();
 
         if (eventId != null){
             lastEventId.set(eventId);

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/SimulatedCloneCluster.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/cluster/SimulatedCloneCluster.java
@@ -12,16 +12,12 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.cluster;
 
-import com.amazonaws.services.neptune.AmazonNeptune;
-
-import java.util.function.Supplier;
-
 public class SimulatedCloneCluster implements CloneClusterStrategy {
 
-    private final Supplier<AmazonNeptune> clientSupplier;
+    private final NeptuneClusterMetadata clusterMetadata;
 
-    public SimulatedCloneCluster(Supplier<AmazonNeptune> clientSupplier) {
-        this.clientSupplier = clientSupplier;
+    public SimulatedCloneCluster(NeptuneClusterMetadata clusterMetadata) {
+        this.clusterMetadata = clusterMetadata;
     }
 
     @Override
@@ -41,13 +37,8 @@ public class SimulatedCloneCluster implements CloneClusterStrategy {
             }
 
             @Override
-            public Supplier<AmazonNeptune> clientSupplier() {
-                return clientSupplier;
-            }
-
-            @Override
             public NeptuneClusterMetadata clusterMetadata() {
-                return NeptuneClusterMetadata.createFromClusterId(connectionConfig.clusterId(), clientSupplier);
+                return clusterMetadata;
             }
 
             @Override

--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/profiles/incremental_export/IncrementalExportEventHandler.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/profiles/incremental_export/IncrementalExportEventHandler.java
@@ -129,9 +129,7 @@ public class IncrementalExportEventHandler implements NeptuneExportServiceEventH
 
     private void getLastEventIdFromStream(Cluster cluster, String streamEndpointType) {
 
-        NeptuneClusterMetadata clusterMetadata = NeptuneClusterMetadata.createFromClusterId(cluster.connectionConfig().clusterId(), cluster.clientSupplier());
-
-        EventId eventId = new GetLastEventId(clusterMetadata, cluster.connectionConfig(), streamEndpointType).execute();
+        EventId eventId = new GetLastEventId(cluster.clusterMetadata(), cluster.connectionConfig(), streamEndpointType).execute();
         if (eventId != null) {
             commitNum.set(eventId.commitNum());
             opNum.set(eventId.opNum());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Previously, neptune-export used a simple heuristic to infer the cluster ID if the cluster ID wasn't supplied as an export parameter. With this change, given an endpoint address, the tool uses the Management API to infer the cluster ID. This is more robust than the previous solution.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
