### PR TITLE
Fix export job hanging when exporting JSON to Kinesis Stream

### DIFF
--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/PropertyGraphExportFormat.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/io/PropertyGraphExportFormat.java
@@ -33,13 +33,13 @@ public enum PropertyGraphExportFormat implements FileExtension {
 
         @Override
         PropertyGraphPrinter createPrinter(OutputWriter writer, LabelSchema labelSchema, PrinterOptions printerOptions) throws IOException {
-            JsonGenerator generator = createJsonGenerator(writer, System.lineSeparator());
+            JsonGenerator generator = createJsonGenerator(writer, writer.lineSeparator());
             return new JsonPropertyGraphPrinter(writer, generator, labelSchema, printerOptions);
         }
 
         @Override
         PropertyGraphPrinter createPrinterForInferredSchema(OutputWriter writer, LabelSchema labelSchema, PrinterOptions printerOptions) throws IOException {
-            JsonGenerator generator = createJsonGenerator(writer, System.lineSeparator());
+            JsonGenerator generator = createJsonGenerator(writer, writer.lineSeparator());
             return new JsonPropertyGraphPrinter(writer, generator, labelSchema, printerOptions,  true);
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes a bug whereby export jobs consisting of exporting raw JSON to a Kinesis Stream would not terminate upon completing the export.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
