### PR TITLE
Add allTypes element to inferred schema, showing all the different ty…

### DIFF
--- a/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/GraphElementSchemas.java
+++ b/neptune-export/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/GraphElementSchemas.java
@@ -57,14 +57,23 @@ public class GraphElementSchemas {
                         boolean isNullable = propertyNode.has("isNullable") &&
                                 propertyNode.path("isNullable").booleanValue();
 
+                        EnumSet<DataType> allTypes = EnumSet.noneOf(DataType.class);
+
+                        if (propertyNode.has("allTypes") ){
+                            ArrayNode allTypesNode = (ArrayNode) propertyNode.path("allTypes");
+                            for (JsonNode jsonNode : allTypesNode) {
+                                allTypes.add(DataType.valueOf(jsonNode.textValue()));
+                            }
+                        }
+
                         graphElementSchemas.getSchemaFor(label).put(
                                 key,
-                                new PropertySchema(key, isNullable, dataType, isMultiValue));
+                                new PropertySchema(key, isNullable, dataType, isMultiValue, allTypes));
                     } else {
                         String property = propertyNode.textValue();
                         graphElementSchemas.getSchemaFor(label).put(
                                 property,
-                                new PropertySchema(property, false, DataType.None, false));
+                                new PropertySchema(property, false, DataType.None, false, EnumSet.noneOf(DataType.class)));
                     }
                 }
             }
@@ -178,11 +187,17 @@ public class GraphElementSchemas {
 
             for (PropertySchema propertySchema : labelSchema.propertySchemas()) {
 
+                ArrayNode allTypesNode = JsonNodeFactory.instance.arrayNode();
+                for (DataType dataType : propertySchema.allTypes()) {
+                    allTypesNode.add(dataType.name());
+                }
+
                 ObjectNode propertyNode = JsonNodeFactory.instance.objectNode();
                 propertyNode.put("property", propertySchema.property().toString());
                 propertyNode.put("dataType", propertySchema.dataType().name());
                 propertyNode.put("isMultiValue", propertySchema.isMultiValue());
                 propertyNode.put("isNullable", propertySchema.isNullable());
+                propertyNode.put("allTypes", allTypesNode);
                 propertiesNode.add(propertyNode);
             }
 

--- a/neptune-export/src/test/java/com/amazonaws/services/neptune/profiles/neptune_ml/v1/PropertyGraphTrainingDataConfigWriterV1FeatureOverrideTests.java
+++ b/neptune-export/src/test/java/com/amazonaws/services/neptune/profiles/neptune_ml/v1/PropertyGraphTrainingDataConfigWriterV1FeatureOverrideTests.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 
 public class PropertyGraphTrainingDataConfigWriterV1FeatureOverrideTests {
 
@@ -41,7 +42,7 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureOverrideTests {
 
         Label label = new Label(Arrays.asList("Person", "Admin"));
         LabelSchema labelSchema = new LabelSchema(label);
-        labelSchema.put("rating", new PropertySchema("rating", isNullable, dataType, isMultiValue));
+        labelSchema.put("rating", new PropertySchema("rating", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("person-1.csv"));
 
@@ -96,9 +97,9 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureOverrideTests {
 
         Label label = new Label(Arrays.asList("Person", "Admin"));
         LabelSchema labelSchema = new LabelSchema(label);
-        labelSchema.put("rating", new PropertySchema("rating", false, DataType.Float, false));
-        labelSchema.put("job", new PropertySchema("job", false, DataType.String, false));
-        labelSchema.put("rank", new PropertySchema("rank", false, DataType.Integer, false));
+        labelSchema.put("rating", new PropertySchema("rating", false, DataType.Float, false, EnumSet.noneOf(DataType.class)));
+        labelSchema.put("job", new PropertySchema("job", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+        labelSchema.put("rank", new PropertySchema("rank", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("person-1.csv"));
 

--- a/neptune-export/src/test/java/com/amazonaws/services/neptune/profiles/neptune_ml/v1/PropertyGraphTrainingDataConfigWriterV1FeatureTest.java
+++ b/neptune-export/src/test/java/com/amazonaws/services/neptune/profiles/neptune_ml/v1/PropertyGraphTrainingDataConfigWriterV1FeatureTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -130,7 +131,7 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureTest {
         GraphElementSchemas nodeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.nodes);
 
         LabelSchema labelSchema = new LabelSchema(new Label(Arrays.asList("Person", "Admin")));
-        labelSchema.put("rating", new PropertySchema("rating", isNullable, dataType, isMultiValue));
+        labelSchema.put("rating", new PropertySchema("rating", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("person-1.csv"));
 
@@ -175,7 +176,7 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureTest {
         GraphElementSchemas nodeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.nodes);
 
         LabelSchema labelSchema = new LabelSchema(new Label(Collections.singletonList("Movie")));
-        labelSchema.put("encoding", new PropertySchema("encoding", isNullable, dataType, isMultiValue));
+        labelSchema.put("encoding", new PropertySchema("encoding", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("movie-1.csv"));
 
@@ -204,7 +205,7 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureTest {
         GraphElementSchemas nodeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.nodes);
 
         LabelSchema labelSchema = new LabelSchema(new Label(Arrays.asList("Person", "Admin")));
-        labelSchema.put("age", new PropertySchema("age", isNullable, dataType, isMultiValue));
+        labelSchema.put("age", new PropertySchema("age", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("person-1.csv"));
 
@@ -250,7 +251,7 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureTest {
         GraphElementSchemas nodeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.nodes);
 
         LabelSchema labelSchema = new LabelSchema(new Label(Collections.singletonList("Movie")));
-        labelSchema.put("class", new PropertySchema("class", isNullable, dataType, isMultiValue));
+        labelSchema.put("class", new PropertySchema("class", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("movie-1.csv"));
 
@@ -295,7 +296,7 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureTest {
         GraphElementSchemas nodeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.nodes);
 
         LabelSchema labelSchema = new LabelSchema(new Label(Collections.singletonList("Movie")));
-        labelSchema.put("movieType", new PropertySchema("movieType", isNullable, dataType, isMultiValue));
+        labelSchema.put("movieType", new PropertySchema("movieType", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("movie-1.csv"));
 
@@ -340,7 +341,7 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureTest {
 
         Label movieLabel = new Label(Collections.singletonList("Movie"));
         LabelSchema labelSchema = new LabelSchema(movieLabel);
-        labelSchema.put("genre", new PropertySchema("genre", isNullable, dataType, isMultiValue));
+        labelSchema.put("genre", new PropertySchema("genre", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("movie-1.csv"));
 
@@ -403,7 +404,7 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureTest {
 
         Label movieLabel = new Label(Collections.singletonList("Movie"));
         LabelSchema labelSchema = new LabelSchema(movieLabel);
-        labelSchema.put("score", new PropertySchema("score", isNullable, dataType, isMultiValue));
+        labelSchema.put("score", new PropertySchema("score", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("movie-1.csv"));
 
@@ -467,7 +468,7 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureTest {
 
             Label movieLabel = new Label(Collections.singletonList("Movie"));
             LabelSchema labelSchema = new LabelSchema(movieLabel);
-            labelSchema.put("score", new PropertySchema("score", isNullable, dataType, isMultiValue));
+            labelSchema.put("score", new PropertySchema("score", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
             nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("movie-1.csv"));
 
@@ -510,7 +511,7 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureTest {
 
         Label movieLabel = new Label(Collections.singletonList("Movie"));
         LabelSchema labelSchema = new LabelSchema(movieLabel);
-        labelSchema.put("score", new PropertySchema("score", isNullable, dataType, isMultiValue));
+        labelSchema.put("score", new PropertySchema("score", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("movie-1.csv"));
 
@@ -556,7 +557,7 @@ public class PropertyGraphTrainingDataConfigWriterV1FeatureTest {
             GraphElementSchemas edgeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.edges);
 
             LabelSchema labelSchema = new LabelSchema(new Label("knows", Collections.singletonList("Person"), Collections.singletonList("Person")));
-            labelSchema.put("strength", new PropertySchema("strength", isNullable, dataType, isMultiValue));
+            labelSchema.put("strength", new PropertySchema("strength", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
             edgeSchemas.addLabelSchema(labelSchema, Collections.singletonList("knows-1.csv"));
 

--- a/neptune-export/src/test/java/com/amazonaws/services/neptune/profiles/neptune_ml/v1/PropertyGraphTrainingDataConfigWriterV1LabelTest.java
+++ b/neptune-export/src/test/java/com/amazonaws/services/neptune/profiles/neptune_ml/v1/PropertyGraphTrainingDataConfigWriterV1LabelTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.EnumSet;
 
 public class PropertyGraphTrainingDataConfigWriterV1LabelTest {
 
@@ -38,7 +39,7 @@ public class PropertyGraphTrainingDataConfigWriterV1LabelTest {
         GraphElementSchemas nodeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.nodes);
 
         LabelSchema labelSchema = new LabelSchema(personLabel);
-        labelSchema.put("role", new PropertySchema("role", isNullable, dataType, isMultiValue));
+        labelSchema.put("role", new PropertySchema("role", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("person-1.csv"));
 
@@ -100,7 +101,7 @@ public class PropertyGraphTrainingDataConfigWriterV1LabelTest {
         GraphElementSchemas nodeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.nodes);
 
         LabelSchema labelSchema = new LabelSchema(personLabel);
-        labelSchema.put("role", new PropertySchema("role", isNullable, dataType, isMultiValue));
+        labelSchema.put("role", new PropertySchema("role", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("person-1.csv"));
 
@@ -141,7 +142,7 @@ public class PropertyGraphTrainingDataConfigWriterV1LabelTest {
         GraphElementSchemas nodeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.nodes);
 
         LabelSchema labelSchema = new LabelSchema(personLabel);
-        labelSchema.put("role", new PropertySchema("role", isNullable, dataType, isMultiValue));
+        labelSchema.put("role", new PropertySchema("role", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         nodeSchemas.addLabelSchema(labelSchema, Collections.singletonList("person-1.csv"));
 
@@ -186,7 +187,7 @@ public class PropertyGraphTrainingDataConfigWriterV1LabelTest {
         GraphElementSchemas edgeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.edges);
 
         LabelSchema labelSchema = new LabelSchema(knowsLabel);
-        labelSchema.put("contact", new PropertySchema("contact", isNullable, dataType, isMultiValue));
+        labelSchema.put("contact", new PropertySchema("contact", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         edgeSchemas.addLabelSchema(labelSchema, Collections.singletonList("knows-1.csv"));
 
@@ -256,7 +257,7 @@ public class PropertyGraphTrainingDataConfigWriterV1LabelTest {
         GraphElementSchemas edgeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.edges);
 
         LabelSchema labelSchema = new LabelSchema(knowsLabel);
-        labelSchema.put("contact", new PropertySchema("contact", isNullable, dataType, isMultiValue));
+        labelSchema.put("contact", new PropertySchema("contact", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         edgeSchemas.addLabelSchema(labelSchema, Collections.singletonList("knows-1.csv"));
 
@@ -300,7 +301,7 @@ public class PropertyGraphTrainingDataConfigWriterV1LabelTest {
         GraphElementSchemas edgeSchemas = graphSchema.graphElementSchemasFor(GraphElementType.edges);
 
         LabelSchema labelSchema = new LabelSchema(knowsLabel);
-        labelSchema.put("contact", new PropertySchema("contact", isNullable, dataType, isMultiValue));
+        labelSchema.put("contact", new PropertySchema("contact", isNullable, dataType, isMultiValue, EnumSet.noneOf(DataType.class)));
 
         edgeSchemas.addLabelSchema(labelSchema, Collections.singletonList("knows-1.csv"));
 

--- a/neptune-export/src/test/java/com/amazonaws/services/neptune/propertygraph/io/CsvPropertyGraphPrinterTest.java
+++ b/neptune-export/src/test/java/com/amazonaws/services/neptune/propertygraph/io/CsvPropertyGraphPrinterTest.java
@@ -25,10 +25,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
@@ -42,7 +39,7 @@ public class CsvPropertyGraphPrinterTest {
 
         StringWriter stringWriter = new StringWriter();
 
-        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, true);
+        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, true, EnumSet.noneOf(DataType.class));
 
         LabelSchema labelSchema = new LabelSchema(new Label("Entity"));
         labelSchema.put("property1", propertySchema1);
@@ -70,7 +67,7 @@ public class CsvPropertyGraphPrinterTest {
 
         StringWriter stringWriter = new StringWriter();
 
-        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, true);
+        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, true, EnumSet.noneOf(DataType.class));
 
         LabelSchema labelSchema = new LabelSchema(new Label("Entity"));
         labelSchema.put("property1", propertySchema1);
@@ -98,7 +95,7 @@ public class CsvPropertyGraphPrinterTest {
 
         StringWriter stringWriter = new StringWriter();
 
-        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, true);
+        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, true, EnumSet.noneOf(DataType.class));
 
         LabelSchema labelSchema = new LabelSchema(new Label("Entity"));
         labelSchema.put("property1", propertySchema1);
@@ -184,7 +181,7 @@ public class CsvPropertyGraphPrinterTest {
     private void testEscapeCharacterAfterPrintPropertiesAndRewrite(String originalValue, String expectedValue, PrinterOptions printerOptions) throws IOException {
         StringWriter stringWriter = new StringWriter();
 
-        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, false);
+        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, false, EnumSet.noneOf(DataType.class));
 
         LabelSchema labelSchema = new LabelSchema(new Label("Entity"));
         labelSchema.put("property1", propertySchema1);

--- a/neptune-export/src/test/java/com/amazonaws/services/neptune/propertygraph/io/JsonPropertyGraphPrinterTest.java
+++ b/neptune-export/src/test/java/com/amazonaws/services/neptune/propertygraph/io/JsonPropertyGraphPrinterTest.java
@@ -56,8 +56,8 @@ public class JsonPropertyGraphPrinterTest {
     public void shouldPrintEmptyListAsListIrrespectiveOfWhetherMultiValueIsTrue() throws Exception {
         StringWriter stringWriter = new StringWriter();
 
-        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, true);
-        PropertySchema propertySchema2 = new PropertySchema("property2", false, DataType.String, false);
+        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, true, EnumSet.noneOf(DataType.class));
+        PropertySchema propertySchema2 = new PropertySchema("property2", false, DataType.String, false, EnumSet.noneOf(DataType.class));
 
         LabelSchema labelSchema = new LabelSchema(new Label("Entity"));
         labelSchema.put("property1", propertySchema1);
@@ -83,7 +83,7 @@ public class JsonPropertyGraphPrinterTest {
     public void shouldPrintSingleValueListAsSingleValueWhenIsMultiValueIsFalse() throws Exception {
         StringWriter stringWriter = new StringWriter();
 
-        PropertySchema propertySchema = new PropertySchema("tags", false, DataType.String, false);
+        PropertySchema propertySchema = new PropertySchema("tags", false, DataType.String, false, EnumSet.noneOf(DataType.class));
         LabelSchema labelSchema = new LabelSchema(new Label("Entity"));
         labelSchema.put("tags", propertySchema);
 
@@ -106,7 +106,7 @@ public class JsonPropertyGraphPrinterTest {
     public void shouldPrintSingleValueListAsSingleValueWhenIsMultiValueIsFalseButStrictCardinalityIsEnforced() throws Exception {
         StringWriter stringWriter = new StringWriter();
 
-        PropertySchema propertySchema = new PropertySchema("tags", false, DataType.String, false);
+        PropertySchema propertySchema = new PropertySchema("tags", false, DataType.String, false, EnumSet.noneOf(DataType.class));
         LabelSchema labelSchema = new LabelSchema(new Label("Entity"));
         labelSchema.put("tags", propertySchema);
 
@@ -131,7 +131,7 @@ public class JsonPropertyGraphPrinterTest {
     public void shouldPrintSingleValueListAsArrayWhenIsMultiValueIsTrue() throws Exception {
         StringWriter stringWriter = new StringWriter();
 
-        PropertySchema propertySchema = new PropertySchema("tags", false, DataType.String, true);
+        PropertySchema propertySchema = new PropertySchema("tags", false, DataType.String, true, EnumSet.noneOf(DataType.class));
         LabelSchema labelSchema = new LabelSchema(new Label("Entity"));
         labelSchema.put("tags", propertySchema);
 
@@ -154,8 +154,8 @@ public class JsonPropertyGraphPrinterTest {
     public void shouldPrintMultiValueListAsArrayIrrespectiveOfWhetherMultiValueIsTrue() throws Exception {
         StringWriter stringWriter = new StringWriter();
 
-        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, true);
-        PropertySchema propertySchema2 = new PropertySchema("property2", false, DataType.String, false);
+        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, true, EnumSet.noneOf(DataType.class));
+        PropertySchema propertySchema2 = new PropertySchema("property2", false, DataType.String, false, EnumSet.noneOf(DataType.class));
 
         LabelSchema labelSchema = new LabelSchema(new Label("Entity"));
         labelSchema.put("property1", propertySchema1);

--- a/neptune-export/src/test/java/com/amazonaws/services/neptune/propertygraph/schema/LabelSchemaTest.java
+++ b/neptune-export/src/test/java/com/amazonaws/services/neptune/propertygraph/schema/LabelSchemaTest.java
@@ -15,6 +15,8 @@ package com.amazonaws.services.neptune.propertygraph.schema;
 import com.amazonaws.services.neptune.propertygraph.Label;
 import org.junit.Test;
 
+import java.util.EnumSet;
+
 import static org.junit.Assert.*;
 
 public class LabelSchemaTest {
@@ -23,60 +25,60 @@ public class LabelSchemaTest {
     public void unioningShouldUpdateDataTypesOfExistingProperties(){
         LabelSchema labelSchema1 = new LabelSchema(new Label("my-label"));
 
-        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
-        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
-        labelSchema1.put("p3", new PropertySchema("p3", false, DataType.Double, false));
+        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema1.put("p3", new PropertySchema("p3", false, DataType.Double, false, EnumSet.noneOf(DataType.class)));
 
         LabelSchema labelSchema2 = new LabelSchema(new Label("my-label"));
 
-        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Double, false));
-        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, true));
-        labelSchema2.put("p3", new PropertySchema("p3", false, DataType.Integer, false));
+        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Double, false, EnumSet.noneOf(DataType.class)));
+        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, true, EnumSet.noneOf(DataType.class)));
+        labelSchema2.put("p3", new PropertySchema("p3", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         LabelSchema result = labelSchema1.union(labelSchema2);
 
         assertEquals(result.getPropertySchema("p1"),
-                new PropertySchema("p1", false, DataType.Double, false));
+                new PropertySchema("p1", false, DataType.Double, false, EnumSet.noneOf(DataType.class)));
         assertEquals(result.getPropertySchema("p2"),
-                new PropertySchema("p2", false, DataType.Integer, true));
+                new PropertySchema("p2", false, DataType.Integer, true, EnumSet.noneOf(DataType.class)));
         assertEquals(result.getPropertySchema("p3"),
-                new PropertySchema("p3", false, DataType.Double, false));
+                new PropertySchema("p3", false, DataType.Double, false, EnumSet.noneOf(DataType.class)));
     }
 
     @Test
     public void unioningShouldAddNewProperties(){
         LabelSchema labelSchema1 = new LabelSchema(new Label("my-label"));
 
-        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
-        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
-        labelSchema1.put("p3", new PropertySchema("p3", false, DataType.Double, false));
+        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema1.put("p3", new PropertySchema("p3", false, DataType.Double, false, EnumSet.noneOf(DataType.class)));
 
         LabelSchema labelSchema2 = new LabelSchema(new Label("my-label"));
 
-        labelSchema2.put("p4", new PropertySchema("p4", false, DataType.String, false));
-        labelSchema2.put("p5", new PropertySchema("p5", false, DataType.Integer, true));
+        labelSchema2.put("p4", new PropertySchema("p4", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+        labelSchema2.put("p5", new PropertySchema("p5", false, DataType.Integer, true, EnumSet.noneOf(DataType.class)));
 
         LabelSchema result = labelSchema1.union(labelSchema2);
 
         assertEquals(5, result.propertySchemas().size());
 
         assertEquals(result.getPropertySchema("p4"),
-                new PropertySchema("p4", false, DataType.String, false));
+                new PropertySchema("p4", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
         assertEquals(result.getPropertySchema("p5"),
-                new PropertySchema("p5", false, DataType.Integer, true));
+                new PropertySchema("p5", false, DataType.Integer, true, EnumSet.noneOf(DataType.class)));
     }
 
     @Test
     public void schemasWithSameLabelAndPropertySchemasAreSame(){
         LabelSchema labelSchema1 = new LabelSchema(new Label("my-label"));
 
-        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
-        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
+        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         LabelSchema labelSchema2 = new LabelSchema(new Label("my-label"));
 
-        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
-        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
+        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         assertTrue(labelSchema1.isSameAs(labelSchema2));
     }
@@ -85,13 +87,13 @@ public class LabelSchemaTest {
     public void schemasWithDifferentLabelsAreNotSame(){
         LabelSchema labelSchema1 = new LabelSchema(new Label("this-label"));
 
-        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
-        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
+        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         LabelSchema labelSchema2 = new LabelSchema(new Label("that-label"));
 
-        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
-        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
+        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         assertFalse(labelSchema1.isSameAs(labelSchema2));
     }
@@ -100,11 +102,11 @@ public class LabelSchemaTest {
     public void schemasWithDifferentPropertiesAreNotSame(){
         LabelSchema labelSchema1 = new LabelSchema(new Label("my-label"));
 
-        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
+        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         LabelSchema labelSchema2 = new LabelSchema(new Label("my-label"));
 
-        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Double, true));
+        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Double, true, EnumSet.noneOf(DataType.class)));
 
         assertFalse(labelSchema1.isSameAs(labelSchema2));
     }
@@ -113,18 +115,18 @@ public class LabelSchemaTest {
     public void schemasWithDifferentNumberOfPropertiesAreNotSame(){
         LabelSchema labelSchema1 = new LabelSchema(new Label("my-label"));
 
-        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
-        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
+        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         LabelSchema labelSchema2 = new LabelSchema(new Label("my-label"));
 
-        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
-        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
-        labelSchema2.put("p3", new PropertySchema("p3", false, DataType.Integer, false));
+        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema2.put("p3", new PropertySchema("p3", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         LabelSchema labelSchema3 = new LabelSchema(new Label("my-label"));
 
-        labelSchema3.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
+        labelSchema3.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         assertFalse(labelSchema1.isSameAs(labelSchema2));
         assertFalse(labelSchema1.isSameAs(labelSchema3));
@@ -134,13 +136,13 @@ public class LabelSchemaTest {
     public void schemasWithPropertySchemasInDifferentOrderAreNotSame(){
         LabelSchema labelSchema1 = new LabelSchema(new Label("my-label"));
 
-        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
-        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
+        labelSchema1.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         LabelSchema labelSchema2 = new LabelSchema(new Label("my-label"));
 
-        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
-        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
+        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         assertFalse(labelSchema1.isSameAs(labelSchema2));
     }
@@ -149,13 +151,13 @@ public class LabelSchemaTest {
     public void schemasWithPropertiesWithDifferentNullableCharacteristicsAreNotSame(){
         LabelSchema labelSchema1 = new LabelSchema(new Label("my-label"));
 
-        labelSchema1.put("p1", new PropertySchema("p1", true, DataType.Integer, false));
-        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
+        labelSchema1.put("p1", new PropertySchema("p1", true, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema1.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         LabelSchema labelSchema2 = new LabelSchema(new Label("my-label"));
 
-        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Integer, false));
-        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, false));
+        labelSchema2.put("p1", new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
+        labelSchema2.put("p2", new PropertySchema("p2", false, DataType.Integer, false, EnumSet.noneOf(DataType.class)));
 
         assertFalse(labelSchema1.isSameAs(labelSchema2));
     }

--- a/neptune-export/src/test/java/com/amazonaws/services/neptune/propertygraph/schema/PropertySchemaTest.java
+++ b/neptune-export/src/test/java/com/amazonaws/services/neptune/propertygraph/schema/PropertySchemaTest.java
@@ -14,14 +14,16 @@ package com.amazonaws.services.neptune.propertygraph.schema;
 
 import org.junit.Test;
 
+import java.util.EnumSet;
+
 import static org.junit.Assert.*;
 
 public class PropertySchemaTest {
 
     @Test
     public void revisionWhereAtLeastOneSchemaIsMultiValueShouldResultInMultiValue(){
-        PropertySchema schema1 = new PropertySchema("p1", false, DataType.Integer, false);
-        PropertySchema schema2 = new PropertySchema("p1", false, DataType.Integer, true);
+        PropertySchema schema1 = new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class));
+        PropertySchema schema2 = new PropertySchema("p1", false, DataType.Integer, true, EnumSet.noneOf(DataType.class));
 
         assertTrue(schema1.union(schema2).isMultiValue());
         assertTrue(schema2.union(schema1).isMultiValue());
@@ -29,8 +31,8 @@ public class PropertySchemaTest {
 
     @Test
     public void revisionWhereAtLeastOneSchemaIsNullableShouldResultInNullable(){
-        PropertySchema schema1 = new PropertySchema("p1", false, DataType.Integer, false);
-        PropertySchema schema2 = new PropertySchema("p1", true, DataType.Integer, false);
+        PropertySchema schema1 = new PropertySchema("p1", false, DataType.Integer, false, EnumSet.noneOf(DataType.class));
+        PropertySchema schema2 = new PropertySchema("p1", true, DataType.Integer, false, EnumSet.noneOf(DataType.class));
 
         assertTrue(schema1.union(schema2).isNullable());
         assertTrue(schema2.union(schema1).isNullable());
@@ -38,7 +40,7 @@ public class PropertySchemaTest {
 
     @Test
     public void shouldEscapePropertyNameContainingColons(){
-        PropertySchema schema = new PropertySchema("p1:a:b:c", false, DataType.Integer, false);
+        PropertySchema schema = new PropertySchema("p1:a:b:c", false, DataType.Integer, false, EnumSet.noneOf(DataType.class));
         assertEquals("p1\\:a\\:b\\:c:int", schema.nameWithDataType(true));
         assertEquals("p1\\:a\\:b\\:c", schema.nameWithoutDataType(true));
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Add allTypes element to inferred schema, showing all the different types for a specific property. Neptune Export infers a schema for the data being exported. In doing so, for each property, it also infers the narrowest type that can contain all the values of that property. The narrowest type becomes the type for the property. With this change, the tool also captures all the different types that led to it inferring the narrowest type. These types are output in the allType field in the config.json file.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
