### PR TITLE
Update neptune-python-utils docs about Neptune Workbench compatibility

### DIFF
--- a/neptune-python-utils/readme.md
+++ b/neptune-python-utils/readme.md
@@ -26,7 +26,7 @@ When using AWS Glue to write data to Neptune, copy the zip file to an S3 bucket.
 
 ### neptune-python-utils and the Neptune Workbench
 
-_neptune-python-utils_ supports Gremlin Python 3.5.x. As such, it is not compatible with the [Neptune Workbench](https://docs.aws.amazon.com/neptune/latest/userguide/graph-notebooks.html), which currently supports 3.4.x.
+_neptune-python-utils_ supports Gremlin Python 3.5.x. As such, it may have conflicts with older instances of [Neptune Workbench](https://docs.aws.amazon.com/neptune/latest/userguide/graph-notebooks.html) that run on 3.4.x. To ensure compatibility, please ensure that you have `graph-notebook==3.0.7` or higher installed.
 
 ## Examples
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- [`graph-notebook>=3.0.7`](https://github.com/aws/graph-notebook/releases/tag/v3.0.7) supports at least `gremlinpython==3.5.1`: https://github.com/aws/graph-notebook/blob/main/setup.py#L69. Updating `neptune-python-utils` docs accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
