### PR TITLE
1.1.0: Use 3.6.2, and broader interpretation of isAvailable

### DIFF
--- a/neptune-gremlin-client/gremlin-client/pom.xml
+++ b/neptune-gremlin-client/gremlin-client/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <javac.target>1.8</javac.target>
         <aws.sdk.version>1.12.38</aws.sdk.version>
-        <gremlin.driver.version>3.5.2</gremlin.driver.version>
+        <gremlin.driver.version>3.6.2</gremlin.driver.version>
         <jackson.databind.version>2.13.4.1</jackson.databind.version>
         <jackson.dataformat.version>2.13.2</jackson.dataformat.version>
         <sigv4.version>2.4.0</sigv4.version>

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/EndpointsType.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/EndpointsType.java
@@ -33,7 +33,8 @@ public enum EndpointsType implements EndpointsSelector {
                     .collect(Collectors.toList());
 
             if (results.isEmpty()) {
-                logger.warn("No available endpoints");
+                logger.warn("Unable to get any endpoints so getting ReaderEndpoint instead");
+                return ReaderEndpoint.getEndpoints(clusterEndpoint, readerEndpoint, instances);
             }
 
             return results;
@@ -51,7 +52,8 @@ public enum EndpointsType implements EndpointsSelector {
                     .collect(Collectors.toList());
 
             if (results.isEmpty()) {
-                logger.warn("No available primary endpoint");
+                logger.warn("Unable to get Primary endpoint so getting ClusterEndpoint instead");
+                return ClusterEndpoint.getEndpoints(clusterEndpoint, readerEndpoint, instances);
             }
 
             return results;
@@ -70,7 +72,8 @@ public enum EndpointsType implements EndpointsSelector {
                     .collect(Collectors.toList());
 
             if (results.isEmpty()) {
-                logger.warn("No available read replica endpoints");
+                logger.warn("Unable to get ReadReplicas endpoints so getting ReaderEndpoint instead");
+                return ReaderEndpoint.getEndpoints(clusterEndpoint, readerEndpoint, instances);
             }
 
             return results;
@@ -92,46 +95,6 @@ public enum EndpointsType implements EndpointsSelector {
                                                Collection<NeptuneInstanceMetadata> instances) {
 
             return Collections.singletonList(readerEndpoint);
-        }
-    },
-
-    PrimaryOrClusterEndpoint {
-        @Override
-        public Collection<String> getEndpoints(String clusterEndpoint,
-                                               String readerEndpoint,
-                                               Collection<NeptuneInstanceMetadata> instances) {
-            List<String> results = instances.stream()
-                    .filter(NeptuneInstanceMetadata::isPrimary)
-                    .filter(NeptuneInstanceMetadata::isAvailable)
-                    .map(NeptuneInstanceMetadata::getEndpoint)
-                    .collect(Collectors.toList());
-
-            if (results.isEmpty()) {
-                logger.warn("Unable to get Primary endpoint so getting ClusterEndpoint instead");
-                return ClusterEndpoint.getEndpoints(clusterEndpoint, readerEndpoint, instances);
-            }
-
-            return results;
-        }
-    },
-    ReadReplicasOrReaderEndpoint {
-        @Override
-        public Collection<String> getEndpoints(String clusterEndpoint,
-                                               String readerEndpoint,
-                                               Collection<NeptuneInstanceMetadata> instances) {
-
-            List<String> results = instances.stream()
-                    .filter(NeptuneInstanceMetadata::isReader)
-                    .filter(NeptuneInstanceMetadata::isAvailable)
-                    .map(NeptuneInstanceMetadata::getEndpoint)
-                    .collect(Collectors.toList());
-
-            if (results.isEmpty()) {
-                logger.warn("Unable to get ReadReplicas endpoints so getting ReaderEndpoint instead");
-                return ReaderEndpoint.getEndpoints(clusterEndpoint, readerEndpoint, instances);
-            }
-
-            return results;
         }
     };
 

--- a/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneInstanceMetadata.java
+++ b/neptune-gremlin-client/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneInstanceMetadata.java
@@ -14,10 +14,14 @@ package software.amazon.neptune.cluster;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
 public class NeptuneInstanceMetadata {
+
+    private static final Collection<String> AVAILABLE_STATES = Arrays.asList("available", "backing-up", "modifying", "upgrading");
 
     private String instanceId;
     private String role;
@@ -28,7 +32,7 @@ public class NeptuneInstanceMetadata {
 
     private final Map<String, String> tags = new HashMap<>();
 
-    public NeptuneInstanceMetadata(){
+    public NeptuneInstanceMetadata() {
 
     }
 
@@ -124,28 +128,28 @@ public class NeptuneInstanceMetadata {
         return tags;
     }
 
-    public boolean hasTag(String tag){
+    public boolean hasTag(String tag) {
         return tags.containsKey(tag);
     }
 
-    public String getTag(String tag){
+    public String getTag(String tag) {
         return tags.get(tag);
     }
 
-    public String getTag(String tag, String defaultValue){
-        if (!tags.containsKey(tag)){
-           return defaultValue;
+    public String getTag(String tag, String defaultValue) {
+        if (!tags.containsKey(tag)) {
+            return defaultValue;
         }
         return tags.get(tag);
     }
 
-    public boolean hasTag(String tag, String value){
+    public boolean hasTag(String tag, String value) {
         return hasTag(tag) && getTag(tag).equals(value);
     }
 
     @JsonIgnore
-    public boolean isAvailable(){
-        return getStatus().equalsIgnoreCase("Available") && endpoint != null;
+    public boolean isAvailable() {
+        return endpoint != null && AVAILABLE_STATES.contains(getStatus().toLowerCase());
     }
 
     @JsonIgnore

--- a/neptune-gremlin-client/readme.md
+++ b/neptune-gremlin-client/readme.md
@@ -6,6 +6,18 @@ The client also provides support for IAM database authentication, and for connec
 
 If your application uses a lot of concurrent clients, you should proxy endpoint refresh requests through a Lambda function that periodically queries the Management API and then caches the results on behalf of your clients. This repository includes an AWS Lambda function that can act as a Neptune endpoints information proxy.
 
+## Dependencies
+
+### Maven
+
+```
+<dependency>
+    <groupId>software.amazon.neptune</groupId>
+    <artifactId>gremlin-client</artifactId>
+    <version>1.0.8</version>
+</dependency>
+```
+
 ## Documentation
 
   - [Recent features](#recent-features)
@@ -27,8 +39,6 @@ If your application uses a lot of concurrent clients, you should proxy endpoint 
     - [TxDemo](#txdemo)
 
 ## Recent features
-
-  - **[Breaking Change February 2023 – version 1.1.0]** The behavior of the `EndpointsType.Primary` and `EndpointsType.ReadReplicas` selectors has changed. Prior to 1.1.0, `EndpointsType.Primary` would return the cluster endpoint if no primary was available, and `EndpointsType.ReadReplicas` would return the reader endpoint if no read replicas were available. Now these selectors return an empty list if the specified type of endpoint is not available. If you want to retain th eold behaviour, use `EndpointsType.PrimaryOrClusterEndpoint` and `EndpointsType.ReadReplicasOrReaderEndpoint` instead.
 
   - **[New February 2023]** AWS Lamba proxy now allows you to mark specific endpoints as being unavailable.
 
@@ -148,13 +158,12 @@ refreshAgent.startPollingNeptuneAPI(
 
 The `EndpointsType` enum provides implementations of `EndpointsSelector` for some common use cases:
 
-  * `EndpointsType.All` –  Return all available instance (primary and read replicas) endpoints.
-  * `EndpointsType.Primary` – Returns the primary (writer) instance endpoint if it is available. (Prior to 1.1.0 this returns the cluster endpoint if the primary instance endpoint is not available.)
-  * `EndpointsType.ReadReplicas` – Returns all available read replica instance endpoints. (Prior to 1.1.0 this returns the reader endpoint if there are no replica instance endpoints.)
-  * `EndpointsType.ClusterEndpoint` – Returns the [cluster endpoint](https://docs.aws.amazon.com/neptune/latest/userguide/feature-overview-endpoints.html).
-  * `EndpointsType.ReaderEndpoint` – Returns the [reader endpoint](https://docs.aws.amazon.com/neptune/latest/userguide/feature-overview-endpoints.html).
-  * `EndpointsType.PrimaryOrClusterEndpoint` – (From 1.1.0) Returns the primary (writer) instance endpoint if it is available, or the cluster endpoint if the primary instance endpoint is not available.
-  * `EndpointsType.ReadReplicasOrReaderEndpoint` – (From 1.1.0) Returns all available read replica instance endpoints, or, if there are no replica instance endpoints, the reader endpoint.
+  * `EndpointsType.All` –  Returns all available instance (writer and read replicas) endpoints, or, if there are no available instance endpoints, the [reader endpoint](https://docs.aws.amazon.com/neptune/latest/userguide/feature-overview-endpoints.html#feature-overview-reader-endpoints).
+  * `EndpointsType.Primary` – Returns the primary (writer) instance endpoint if it is available, or the [cluster endpoint](https://docs.aws.amazon.com/neptune/latest/userguide/feature-overview-endpoints.html#feature-overview-cluster-endpoints) if the primary instance endpoint is not available.
+  * `EndpointsType.ReadReplicas` – Returns all available read replica instance endpoints, or, if there are no replica instance endpoints, the [reader endpoint](https://docs.aws.amazon.com/neptune/latest/userguide/feature-overview-endpoints.html#feature-overview-reader-endpoints).
+  * `EndpointsType.ClusterEndpoint` – Returns the [cluster endpoint](https://docs.aws.amazon.com/neptune/latest/userguide/feature-overview-endpoints.html#feature-overview-cluster-endpoints).
+  * `EndpointsType.ReaderEndpoint` – Returns the [reader endpoint](https://docs.aws.amazon.com/neptune/latest/userguide/feature-overview-endpoints.html#feature-overview-reader-endpoints).
+
 
 ### Connect the ClusterEndpointsRefreshAgent to a Lambda Proxy when you have many clients
 


### PR DESCRIPTION
*Issue #, if available:*

1.1.0: Instance endpoints will be considered available while the instance is updating.
 Use 3.6.2 TinkerPop driver.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
