### PR TITLE
ReservedConcurrentExecutions Removed

### DIFF
--- a/export-neptune-to-elasticsearch/cloudformation-templates/export-neptune-to-elasticsearch.json
+++ b/export-neptune-to-elasticsearch/cloudformation-templates/export-neptune-to-elasticsearch.json
@@ -551,8 +551,7 @@
         },
         "MemorySize": 128,
         "Runtime": "python3.9",
-        "Timeout": "30",
-        "ReservedConcurrentExecutions": 1
+        "Timeout": "30"
       }
     },
     "KinesisToElasticSearchLambda": {
@@ -660,9 +659,6 @@
         "MemorySize": 1024,
         "Runtime": "python3.9",
         "Timeout": "900",
-        "ReservedConcurrentExecutions": {
-          "Ref": "KinesisShardCount"
-        },
         "VpcConfig": {
           "SecurityGroupIds": [
             {


### PR DESCRIPTION
*Issue #, if available:*

#324 


*Description of changes:*

Removed the hardcoded `Reserved` Concurrent Executions` flag from Cloudformation template. Experimenting this with increased values/non-variables might help some, but as of AWS documentation [here](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html); It it better we leave it to default.  Tested with my production setup 👯 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
