### PR TITLE
Update build.sh for Issue 330

### DIFF
--- a/neptune-python-utils/build.sh
+++ b/neptune-python-utils/build.sh
@@ -9,7 +9,7 @@ virtualenv temp --python=python3.8
 source temp/bin/activate
 cd temp
 pip install gremlinpython==3.5.1
-pip install requests
+pip install requests==2.29.0
 pip install backoff
 pip install cchardet
 pip install aiodns


### PR DESCRIPTION
Pinning requests to 2.29.0 to avoid importing urllib3 2.0 and resolve the conflict with lack of support for that library in botocore to resolve Issue #330.

Issue #, if available: 330

*Description of changes:*
Running as a library referenced in Glue 4 results in the exception:
from neptune_python_utils.glue_neptune_connection_info import GlueNeptuneConnectionInfo  
File "/tmp/neptune_python_utils.zip/neptune_python_utils/glue_neptune_connection_info.py", 
...
line 34, in <module> import botocore.httpsession File "/home/spark/.local/lib/python3.10/site-packages/botocore/httpsession.py", line 21, in <module> from urllib3.util.ssl_ import ( ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_' (/tmp/neptune_python_utils.zip/urllib3/util/ssl_.py)

This is due to a conflict between botocore not supporting urllib3 2.0 and newer versions of releases using urllib3 2.0.  By pinning releases to 2.29.0, it resolves this conflict. This was tested by running the old library in Glue 4 and failing then running the revised library in Glue 4 and completing successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
