### PR TITLE
removing provisioned workload evaluator

### DIFF
--- a/neptune-serverless-evaluator/README.md
+++ b/neptune-serverless-evaluator/README.md
@@ -1,5 +1,5 @@
 ## Neptune Serverless Cost Evaluator
-Neptune offers On-Demand provisioned instances and serverless instances which to accommodate variety of scaling up or down needs.   Choosing between 2 modes is often a decision of cost and requires understanding access patterns. I will walk through some of the decision factors for new workloads and also show how you can use cloudwatch logs to check if provisioned or serverless will be a better for your workload. 
+Neptune offers On-Demand provisioned instances and serverless instances which to accommodate variety of scaling up or down needs.   Choosing between 2 modes is often a decision of cost and requires understanding access patterns. I will walk through some of the decision factors for new workloads and also show how you can use cloudwatch logs to check if current workload on Neptune Serverless instance will be cheaper on Neptune Provisioned instances.
 
 ### Minimum IAM policies required
 * AmazonRDSReadOnlyAccess
@@ -27,25 +27,7 @@ Parameter names:
 | -p, --period | Number of days datapoints collected from cloudwatch      |    14 |
 
 
-Example call to evaluate if current provisioned workload will be cheaper on serverless:
-```
-python pricing.py -n database-1 -p 1 -r us-east-1
-
-Output:
-Region : us-east-1
-Instance name : database-1
-Instance type : db.t3.medium
-Data collection period : 1 days
-Cost of running on-demand provisioned instance : $0.098/hr
-Total cost of running provisioned for 1 days : $2.31
-Total cost of running serverless for 1 days : $3.79
-Maximum NCU utilization : 1
-Minimum NCU utilization : 1
-Average NCU utilization : 1
-Total data points : 1415
-```
-
-Another Example of checking if OnDemand provisioned instances are cheaper than running Neptune serverless:
+Example of checking if OnDemand provisioned instances are cheaper than running Neptune serverless:
 
 ```
 python pricing.py -n database-2-instance-1 -p 1 -r us-east-1

--- a/neptune-serverless-evaluator/pricing.py
+++ b/neptune-serverless-evaluator/pricing.py
@@ -257,7 +257,8 @@ def main():
    if args.instance_type == 'db.serverless':
        parse_serverless_cw_logs(output)
    else:
-       parse_metrics(output)
+       print("\nInstance name '{}' is of type provisioned. \nThis evaluator only current Neptune Serverless workload for Neptune Provisioned.\n ".format(args.name))
+       #parse_metrics(output)
    
    
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Neptune serverless workload evaluator for provisioned instances currently does not produce expected result. Will address this as an issue in future releases. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
