### PR TITLE
Add neo4j-to-neptune.sh

### DIFF
--- a/neo4j-to-neptune/bin/neo4j-to-neptune.sh
+++ b/neo4j-to-neptune/bin/neo4j-to-neptune.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+jar=$(find . -name neo4j-to-neptune.jar -print -quit)
+java -jar ${jar} "$@"


### PR DESCRIPTION
Issue #365 

Description of changes:  Adding `neo4j-to-neptune.sh` wrapper script as is referenced in docs and in JAR file help.

Execute via `./bin/neo4j-to-neptune.sh` from the root directory of the Neo4j-to-Neptune utility after compiling the JAR file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
